### PR TITLE
Add support for specifying an explicit group when dropping privileges.

### DIFF
--- a/main.c
+++ b/main.c
@@ -129,6 +129,7 @@ main_usage(void)
 "  -e engine   specify default NAT engine to use (default: %s)\n"
 "  -E          list available NAT engines and exit\n"
 "  -u user     drop privileges to user (default if run as root: nobody)\n"
+"  -m group    when dropping user privileges via -u, set the target group (default: primary group of the user)\n"
 "  -j jaildir  chroot() to jaildir (impacts -S and sni, see manual page)\n"
 "  -p pidfile  write pid to pidfile (default: no pid file)\n"
 "  -l logfile  connect log: log one line summary per connection to logfile\n"
@@ -229,7 +230,7 @@ main(int argc, char *argv[])
 	}
 
 	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z
-	                    "k:c:C:K:t:OPs:e:Eu:j:p:l:L:S:dDVh")) != -1) {
+	                    "k:c:C:K:t:OPs:e:Eu:m:j:p:l:L:S:dDVh")) != -1) {
 		switch (ch) {
 			case 'c':
 				if (opts->cacrt)
@@ -401,6 +402,11 @@ main(int argc, char *argv[])
 				if (opts->dropuser)
 					free(opts->dropuser);
 				opts->dropuser = strdup(optarg);
+				break;
+			case 'm':
+				if (opts->dropgroup)
+					free(opts->dropgroup);
+				opts->dropgroup = strdup(optarg);
 				break;
 			case 'p':
 				if (opts->pidfile)
@@ -607,7 +613,7 @@ main(int argc, char *argv[])
 	}
 
 	/* Drop privs, chroot, detach from TTY */
-	if (sys_privdrop(opts->dropuser, opts->jaildir) == -1) {
+	if (sys_privdrop(opts->dropuser, opts->dropgroup, opts->jaildir) == -1) {
 		fprintf(stderr, "%s: failed to drop privileges: %s\n",
 		                argv0, strerror(errno));
 		exit(EXIT_FAILURE);

--- a/opts.c
+++ b/opts.c
@@ -88,6 +88,9 @@ opts_free(opts_t *opts)
 	if (opts->dropuser) {
 		free(opts->dropuser);
 	}
+	if (opts->dropgroup) {
+		free(opts->dropgroup);
+	}
 	if (opts->jaildir) {
 		free(opts->jaildir);
 	}

--- a/opts.h
+++ b/opts.h
@@ -63,6 +63,7 @@ typedef struct opts {
 	char *ciphers;
 	char *tgcrtdir;
 	char *dropuser;
+	char *dropgroup;
 	char *jaildir;
 	char *pidfile;
 	char *connectlog;

--- a/sys.h
+++ b/sys.h
@@ -35,7 +35,7 @@
 #include <sys/socket.h>
 #include <stdint.h>
 
-int sys_privdrop(const char *, const char *) WUNRES;
+int sys_privdrop(const char *, const char *, const char *) WUNRES;
 
 int sys_pidf_open(const char *) NONNULL(1) WUNRES;
 int sys_pidf_write(int) WUNRES;


### PR DESCRIPTION
Howdy --

I wanted to be able to run under a custom uid/gid pair, and key pf(4) rules based on gid; this patch adds support for explicitly specifying a gid via  new -m flag (for `membership` -- -g was already claimed), overriding the standard pw_gid.

Cheers,
Landon
