### PR TITLE
fixed MD to SHA-256 and RSA-2048 Pubkey; Fixed log delimiter char to .

### DIFF
--- a/log.c
+++ b/log.c
@@ -31,6 +31,7 @@
 #include "logger.h"
 #include "sys.h"
 #include "attrib.h"
+#include "replace.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -282,6 +283,7 @@ log_content_format_pathspec(const char *logspec, char *srcaddr, char *dstaddr,
 	/* set up buffer to hold our generated file path */
 	size_t path_buflen = PATH_BUF_INC;
 	char *path_buf = malloc(path_buflen);
+	char *cleaned_addr;
 	if (path_buf == NULL) {
 		log_err_printf("failed to allocate path buffer\n");
 		return NULL;
@@ -316,12 +318,14 @@ log_content_format_pathspec(const char *logspec, char *srcaddr, char *dstaddr,
 				elem_len = 1;
 				break;
 			case 'd':
-				elem = dstaddr;
-				elem_len = strlen(dstaddr);
+				cleaned_addr = replace_str2(dstaddr, ":", ".");
+				elem = cleaned_addr;
+				elem_len = strlen(cleaned_addr);
 				break;
 			case 's':
-				elem = srcaddr;
-				elem_len = strlen(srcaddr);
+				cleaned_addr = replace_str2(srcaddr, ":", ".");
+                                elem = cleaned_addr;
+				elem_len = strlen(cleaned_addr);
 				break;
 			case 'x':
 				if (exec_path) {

--- a/main.c
+++ b/main.c
@@ -638,7 +638,7 @@ main(int argc, char *argv[])
 #endif /* __APPLE__ */
 	}
 	if (opts_has_ssl_spec(opts) && opts->cakey && !opts->key) {
-		opts->key = ssl_key_genrsa(1024);
+		opts->key = ssl_key_genrsa(2048);
 		if (!opts->key) {
 			fprintf(stderr, "%s: error generating RSA key:\n",
 			                argv0);

--- a/opts.c
+++ b/opts.c
@@ -143,11 +143,6 @@ opts_proto_force(opts_t *opts, const char *optarg, const char *argv0)
 		opts->sslmethod = SSLv2_method;
 	} else
 #endif /* SSL_OP_NO_SSLv2 && WITH_SSLV2 */
-#ifdef SSL_OP_NO_SSLv3
-	if (!strcmp(optarg, "ssl3")) {
-		opts->sslmethod = SSLv3_method;
-	} else
-#endif /* SSL_OP_NO_SSLv3 */
 #ifdef SSL_OP_NO_TLSv1
 	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
 		opts->sslmethod = TLSv1_method;
@@ -182,11 +177,6 @@ opts_proto_disable(opts_t *opts, const char *optarg, const char *argv0)
 		opts->no_ssl2 = 1;
 	} else
 #endif /* SSL_OP_NO_SSLv2 && WITH_SSLV2 */
-#ifdef SSL_OP_NO_SSLv3
-	if (!strcmp(optarg, "ssl3")) {
-		opts->no_ssl3 = 1;
-	} else
-#endif /* SSL_OP_NO_SSLv3 */
 #ifdef SSL_OP_NO_TLSv1
 	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
 		opts->no_tls10 = 1;
@@ -219,9 +209,6 @@ opts_proto_dbg_dump(opts_t *opts)
 #if defined(SSL_OP_NO_SSLv2) && defined(WITH_SSLV2)
 	               (opts->sslmethod == SSLv2_method) ? "nossl2" :
 #endif /* SSL_OP_NO_SSLv2 && WITH_SSLV2 */
-#ifdef SSL_OP_NO_SSLv3
-	               (opts->sslmethod == SSLv3_method) ? "ssl3" :
-#endif /* SSL_OP_NO_SSLv3 */
 #ifdef SSL_OP_NO_TLSv1
 	               (opts->sslmethod == TLSv1_method) ? "tls10" :
 #endif /* SSL_OP_NO_TLSv1 */
@@ -236,9 +223,6 @@ opts_proto_dbg_dump(opts_t *opts)
 	               opts->no_ssl2 ? " -ssl2" :
 #endif /* SSL_OP_NO_SSLv2 && WITH_SSLV2 */
 	               "",
-#ifdef SSL_OP_NO_SSLv3
-	               opts->no_ssl3 ? " -ssl3" :
-#endif /* SSL_OP_NO_SSLv3 */
 	               "",
 #ifdef SSL_OP_NO_TLSv1
 	               opts->no_tls10 ? " -tls10" :

--- a/opts.h
+++ b/opts.h
@@ -61,9 +61,6 @@ typedef struct opts {
 #if defined(SSL_OP_NO_SSLv2) && defined(WITH_SSLV2)
 	unsigned int no_ssl2 : 1;
 #endif /* SSL_OP_NO_SSLv2 && WITH_SSLV2 */
-#ifdef SSL_OP_NO_SSLv3
-	unsigned int no_ssl3 : 1;
-#endif /* SSL_OP_NO_SSLv3 */
 #ifdef SSL_OP_NO_TLSv1
 	unsigned int no_tls10 : 1;
 #endif /* SSL_OP_NO_TLSv1 */

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -641,11 +641,6 @@ pxy_srcsslctx_create(pxy_conn_ctx_t *ctx, X509 *crt, STACK_OF(X509) *chain,
 	}
 #endif /* WITH_SSLV2 */
 #endif /* !SSL_OP_NO_SSLv2 */
-#ifdef SSL_OP_NO_SSLv3
-	if (ctx->opts->no_ssl3) {
-		SSL_CTX_set_options(sslctx, SSL_OP_NO_SSLv3);
-	}
-#endif /* SSL_OP_NO_SSLv3 */
 #ifdef SSL_OP_NO_TLSv1
 	if (ctx->opts->no_tls10) {
 		SSL_CTX_set_options(sslctx, SSL_OP_NO_TLSv1);
@@ -997,11 +992,6 @@ pxy_dstssl_create(pxy_conn_ctx_t *ctx)
 	}
 #endif /* WITH_SSLV2 */
 #endif /* !SSL_OP_NO_SSLv2 */
-#ifdef SSL_OP_NO_SSLv3
-	if (ctx->opts->no_ssl3) {
-		SSL_CTX_set_options(sslctx, SSL_OP_NO_SSLv3);
-	}
-#endif /* SSL_OP_NO_SSLv3 */
 #ifdef SSL_OP_NO_TLSv1
 	if (ctx->opts->no_tls10) {
 		SSL_CTX_set_options(sslctx, SSL_OP_NO_TLSv1);

--- a/replace.c
+++ b/replace.c
@@ -1,0 +1,58 @@
+/* from http://creativeandcritical.net/str-replace-c
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+char *replace_str2(const char *str, const char *old, const char *new)
+{
+	char *ret, *r;
+	const char *p, *q;
+	size_t oldlen = strlen(old);
+	size_t count, retlen, newlen = strlen(new);
+	int samesize = (oldlen == newlen);
+
+	if (!samesize) {
+		for (count = 0, p = str; (q = strstr(p, old)) != NULL; p = q + oldlen)
+			count++;
+		/* This is undefined if p - str > PTRDIFF_MAX */
+		retlen = p - str + strlen(p) + count * (newlen - oldlen);
+	} else
+		retlen = strlen(str);
+
+	if ((ret = malloc(retlen + 1)) == NULL)
+		return NULL;
+
+	r = ret, p = str;
+	while (1) {
+		/* If the old and new strings are different lengths - in other
+		 * words we have already iterated through with strstr above,
+		 * and thus we know how many times we need to call it - then we
+		 * can avoid the final (potentially lengthy) call to strstr,
+		 * which we already know is going to return NULL, by
+		 * decrementing and checking count.
+		 */
+		if (!samesize && !count--)
+			break;
+		/* Otherwise i.e. when the old and new strings are the same
+		 * length, and we don't know how many times to call strstr,
+		 * we must check for a NULL return here (we check it in any
+		 * event, to avoid further conditions, and because there's
+		 * no harm done with the check even when the old and new
+		 * strings are different lengths).
+		 */
+		if ((q = strstr(p, old)) == NULL)
+			break;
+		/* This is undefined if q - p > PTRDIFF_MAX */
+		ptrdiff_t l = q - p;
+		memcpy(r, p, l);
+		r += l;
+		memcpy(r, new, newlen);
+		r += newlen;
+		p = q + oldlen;
+	}
+	strcpy(r, p);
+
+	return ret;
+}

--- a/replace.h
+++ b/replace.h
@@ -1,0 +1,4 @@
+/* from http://creativeandcritical.net/str-replace-c
+*/
+
+char *replace_str2(const char *str, const char *old, const char *new);

--- a/ssl.c
+++ b/ssl.c
@@ -822,7 +822,7 @@ ssl_x509_forge(X509 *cacrt, EVP_PKEY *cakey, X509 *origcrt,
 	switch (EVP_PKEY_type(cakey->type)) {
 #ifndef OPENSSL_NO_RSA
 		case EVP_PKEY_RSA:
-			md = EVP_sha1();
+			md = EVP_sha256();
 			break;
 #endif /* !OPENSSL_NO_RSA */
 #ifndef OPENSSL_NO_DSA

--- a/ssl.h
+++ b/ssl.h
@@ -86,11 +86,6 @@ X509 * ssl_ssl_cert_get(SSL *);
 #else /* !(SSL_OP_NO_SSLv2 && WITH_SSLV2) */
 #define SSL2_S ""
 #endif /* !(SSL_OP_NO_SSLv2 && WITH_SSLV2) */
-#ifdef SSL_OP_NO_SSLv3
-#define SSL3_S "ssl3 "
-#else /* !SSL_OP_NO_SSLv3 */
-#define SSL3_S ""
-#endif /* !SSL_OP_NO_SSLv3 */
 #ifdef SSL_OP_NO_TLSv1
 #define TLS10_S "tls10 "
 #else /* !SSL_OP_NO_TLSv1 */
@@ -106,7 +101,7 @@ X509 * ssl_ssl_cert_get(SSL *);
 #else /* !SSL_OP_NO_TLSv1_2 */
 #define TLS12_S ""
 #endif /* !SSL_OP_NO_TLSv1_2 */
-#define SSL_PROTO_SUPPORT_S SSL2_S SSL3_S TLS10_S TLS11_S TLS12_S
+#define SSL_PROTO_SUPPORT_S TLS10_S TLS11_S TLS12_S
 
 void ssl_openssl_version(void);
 int ssl_init(void) WUNRES;


### PR DESCRIPTION
This patch fixes the Message Digest to SHA-256, a requirement for modern browsers.
It also ups the keysize to 2048, as some systems will require this larger key size to be considered secure.

It also includes a str replace function that modifies the : (which is an invalid char on windows) to a . allowing the log files to be readable from any OS.