### PR TITLE
Provide support for ALPN extensions (HTTP/2)

### DIFF
--- a/pxyconn.c
+++ b/pxyconn.c
@@ -133,6 +133,8 @@ typedef struct pxy_conn_ctx {
 
 	/* server name indicated by client in SNI TLS extension */
 	char *sni;
+	unsigned char *alpn;
+	unsigned int alpnLen;
 
 	/* log strings from socket */
 	char *srchost_str;
@@ -288,6 +290,9 @@ pxy_conn_ctx_free(pxy_conn_ctx_t *ctx)
 	if (ctx->sni) {
 		free(ctx->sni);
 	}
+	if (ctx->alpn) {
+		free(ctx->alpn);
+	}
 	if (WANT_CONTENT_LOG(ctx) && ctx->logctx) {
 		if (log_content_close(&ctx->logctx) == -1) {
 			log_err_printf("Warning: Content log close failed\n");
@@ -306,6 +311,15 @@ static void pxy_fd_readcb(evutil_socket_t, short, void *);
 /* forward declaration of OpenSSL callbacks */
 #ifndef OPENSSL_NO_TLSEXT
 static int pxy_ossl_servername_cb(SSL *ssl, int *al, void *arg);
+#ifndef OPENSSL_NO_ALPNEXT
+static int pxy_ossl_alpn_select_cb(
+		UNUSED SSL *ssl,
+		const unsigned char **out,
+		unsigned char *outlen,
+		UNUSED const unsigned char *in,
+		UNUSED unsigned int inlen,
+		void *arg);
+#endif /* !OPENSSL_NO_ALPNEXT */
 #endif /* !OPENSSL_NO_TLSEXT */
 static int pxy_ossl_sessnew_cb(SSL *, SSL_SESSION *);
 static void pxy_ossl_sessremove_cb(SSL_CTX *, SSL_SESSION *);
@@ -714,6 +728,9 @@ pxy_srcsslctx_create(pxy_conn_ctx_t *ctx, X509 *crt, STACK_OF(X509) *chain,
 #ifndef OPENSSL_NO_TLSEXT
 	SSL_CTX_set_tlsext_servername_callback(sslctx, pxy_ossl_servername_cb);
 	SSL_CTX_set_tlsext_servername_arg(sslctx, ctx);
+#ifndef OPENSSL_NO_ALPNEXT
+	SSL_CTX_set_alpn_select_cb(sslctx, pxy_ossl_alpn_select_cb, ctx);
+#endif /* !OPENSSL_NO_ALPNEXT */
 #endif /* !OPENSSL_NO_TLSEXT */
 #ifndef OPENSSL_NO_DH
 	if (ctx->opts->dh) {
@@ -944,6 +961,28 @@ pxy_srcssl_create(pxy_conn_ctx_t *ctx, SSL *origssl)
 		ctx->enomem = 1;
 		return NULL;
 	}
+
+#ifndef OPENSSL_NO_ALPNEXT
+	/* Try and get ALPN reply from real server. */
+	const unsigned char *alpn = 0;
+	unsigned int alpnLen = 0;
+	SSL_get0_alpn_selected(origssl, &alpn, &alpnLen);
+
+	if (alpn != 0 && alpnLen > 0) {
+
+		if ( ctx->alpn != 0 ) {
+			free(ctx->alpn);
+			ctx->alpn = 0;
+			ctx->alpnLen = 0;
+		}
+		ctx->alpn = malloc(alpnLen);
+		memcpy(ctx->alpn, alpn, alpnLen);
+		ctx->alpnLen = alpnLen;
+
+		log_dbg_printf("Received ALPN from real server.\n");
+	}
+#endif /* !OPENSSL_NO_ALPNEXT */
+
 	SSL *ssl = SSL_new(sslctx);
 	SSL_CTX_free(sslctx); /* SSL_new() increments refcount */
 	if (!ssl) {
@@ -1067,6 +1106,27 @@ pxy_ossl_servername_cb(SSL *ssl, UNUSED int *al, void *arg)
 
 	return SSL_TLSEXT_ERR_OK;
 }
+#ifndef OPENSSL_NO_ALPNEXT
+static int
+pxy_ossl_alpn_select_cb(
+		UNUSED SSL *ssl,
+		const unsigned char **out,
+		unsigned char *outlen,
+		UNUSED const unsigned char *in,
+		UNUSED unsigned int inlen,
+		void *arg)
+{
+	pxy_conn_ctx_t *ctx = (pxy_conn_ctx_t *)arg;
+
+	*out = ctx->alpn;
+	*outlen = ctx->alpnLen;
+
+	log_dbg_printf("ALPN callback, need to relay choice to real client\n");
+
+	return SSL_TLSEXT_ERR_OK;
+}
+#endif /* !OPENSSL_NO_ALPNEXT */
+
 #endif /* !OPENSSL_NO_TLSEXT */
 
 /*
@@ -1100,6 +1160,11 @@ pxy_dstssl_create(pxy_conn_ctx_t *ctx)
 	if (ctx->sni) {
 		SSL_set_tlsext_host_name(ssl, ctx->sni);
 	}
+#ifndef OPENSSL_NO_ALPNEXT
+	if (ctx->alpn) {
+		SSL_set_alpn_protos(ssl, ctx->alpn, ctx->alpnLen);
+	}
+#endif /* !OPENSSL_NO_ALPNEXT */
 #endif /* !OPENSSL_NO_TLSEXT */
 
 #ifdef SSL_MODE_RELEASE_BUFFERS
@@ -1515,7 +1580,8 @@ pxy_conn_autossl_peek_and_upgrade(pxy_conn_ctx_t *ctx)
 	if (evbuffer_peek(inbuf, 1024, 0, vec_out, 1)) {
 		if (ssl_tls_clienthello_parse(vec_out[0].iov_base,
 		                              vec_out[0].iov_len,
-		                              0, &chello, &ctx->sni) == 0) {
+		                              0, &chello, &ctx->sni,
+		                              &ctx->alpn, &ctx->alpnLen) == 0) {
 			if (OPTS_DEBUG(ctx->opts)) {
 				log_dbg_printf("Peek found ClientHello\n");
 			}
@@ -1986,7 +2052,7 @@ connected:
 		           SSL_R_SSLV3_ALERT_HANDSHAKE_FAILURE) {
 			/* these can happen due to client cert auth,
 			 * only log error if debugging is activated */
-			log_dbg_printf("Error from bufferevent: "
+			log_dbg_printf("Error from bufferevent_dbg: "
 			               "%i:%s %lu:%i:%s:%i:%s:%i:%s\n",
 			               errno,
 			               errno ? strerror(errno) : "-",
@@ -2013,7 +2079,7 @@ connected:
 			}
 		} else {
 			/* real errors */
-			log_err_printf("Error from bufferevent: "
+			log_err_printf("Error from bufferevent_err: "
 			               "%i:%s %lu:%i:%s:%i:%s:%i:%s\n",
 			               errno,
 			               errno ? strerror(errno) : "-",
@@ -2242,7 +2308,7 @@ pxy_fd_readcb(MAYBE_UNUSED evutil_socket_t fd, UNUSED short what, void *arg)
 			return;
 		}
 
-		rv = ssl_tls_clienthello_parse(buf, n, 0, &chello, &ctx->sni);
+		rv = ssl_tls_clienthello_parse(buf, n, 0, &chello, &ctx->sni, &ctx->alpn, &ctx->alpnLen);
 		if ((rv == 1) && !chello) {
 			log_err_printf("Peeking did not yield a (truncated) "
 			               "ClientHello message, "

--- a/ssl.h
+++ b/ssl.h
@@ -57,6 +57,9 @@
 #if (OPENSSL_VERSION_NUMBER < 0x0090802FL) && !defined(OPENSSL_NO_EC)
 #define OPENSSL_NO_EC
 #endif
+#if (OPENSSL_VERSION_NUMBER < 0x10002000) && !defined(OPENSSL_NO_ALPNEXT)
+#define OPENSSL_NO_ALPNEXT
+#endif
 
 /*
  * The constructors returning a SSL_METHOD * were changed to return
@@ -84,6 +87,10 @@ X509 * ssl_ssl_cert_get(SSL *);
 #ifndef TLSEXT_MAXLEN_host_name
 #define TLSEXT_MAXLEN_host_name 255
 #endif /* !TLSEXT_MAXLEN_host_name */
+
+#ifndef TLSEXT_MAXLEN_alpn
+#define TLSEXT_MAXLEN_alpn 255
+#endif /* !TLSEXT_MAXLEN_alpn */
 #endif /* OPENSSL_NO_TLSEXT */
 
 /*
@@ -198,7 +205,8 @@ int ssl_session_is_valid(SSL_SESSION *) NONNULL(1);
 int ssl_is_ocspreq(const unsigned char *, size_t) NONNULL(1) WUNRES;
 
 int ssl_tls_clienthello_parse(const unsigned char *, ssize_t, int,
-                              const unsigned char **, char **)
+                              const unsigned char **, char **,
+                              unsigned char **, unsigned int *)
     NONNULL(1,4) WUNRES;
 int ssl_dnsname_match(const char *, size_t, const char *, size_t)
     NONNULL(1,3) WUNRES;


### PR DESCRIPTION
To propagate the original ALPN extension we needed to make changes at
four points:

1. On original ClientHello. Here we piggyback on the early peak into the
ClientHello message to extract SNI and also extract the full ALPN
extension. We are not being too smart about it; if it is not fully
available, we just skip it (thus falling back to the original
behaviour). We store this in the ctx.

2. On "fake" ClientHello to the original destination, we set the ALPN we
extracted during (1) above (available in the ctx).

3. On "fake" ServerHello from the original destination, we extract the
ALPN that the real server accepted. We store this in the ctx, same
location as (1) above (so original list is gone, but we don't need it
anymore).

4. On original connection establishment, we add a new callback (as the
"fake" server) to choose protocol from the ALPN list provided by the
original ClientHello (1). Here we just set whatever the real server
chose in (3).

We rely on libssl 1.0.2 for ALPN functions and callbacks. OPENSSL
version checks added to toggle ALPN support.