### PR TITLE
Writing/Mirroring clear traffic to pcap-file/network-Interface

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -226,6 +226,8 @@ PKGS+=		$(shell $(PKGCONFIG) $(PCFLAGS) --exists libevent_openssl \
 		&& echo libevent_openssl)
 PKGS+=		$(shell $(PKGCONFIG) $(PCFLAGS) --exists libevent_pthreads \
 		&& echo libevent_pthreads)
+PKGS+=		$(shell $(PKGCONFIG) $(PCFLAGS) --exists libnet \
+		&& echo libnet)
 endif
 TPKGS:=		
 ifndef CHECK_BASE
@@ -288,7 +290,7 @@ endif
 ifdef OPENSSL_FOUND
 PKG_CPPFLAGS+=	-I$(OPENSSL_FOUND)/include
 PKG_LDFLAGS+=	-L$(OPENSSL_FOUND)/lib
-PKG_LIBS+=	-lssl -lcrypto -lz
+PKG_LIBS+=	-lssl -lcrypto -lz 
 endif
 ifdef LIBEVENT_FOUND
 PKG_CPPFLAGS+=	-I$(LIBEVENT_FOUND)/include
@@ -340,10 +342,10 @@ CFLAGS+=	$(PKG_CFLAGS) \
 CPPFLAGS+=	$(PKG_CPPFLAGS) $(CPPDEFS) $(FEATURES)
 TCPPFLAGS+=	$(TPKG_CPPFLAGS)
 LDFLAGS+=	$(PKG_LDFLAGS)
-LIBS+=		$(PKG_LIBS)
+LIBS+=		$(PKG_LIBS) -lnet
 
 ifneq ($(shell uname),Darwin)
-CFLAGS+=	-pthread
+CFLAGS+=	-g -pthread
 LDFLAGS+=	-pthread
 endif
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -345,7 +345,7 @@ LDFLAGS+=	$(PKG_LDFLAGS)
 LIBS+=		$(PKG_LIBS) -lnet
 
 ifneq ($(shell uname),Darwin)
-CFLAGS+=	-g -pthread
+CFLAGS+=	-pthread
 LDFLAGS+=	-pthread
 endif
 

--- a/arpop.c
+++ b/arpop.c
@@ -1,0 +1,151 @@
+/*
+ * arpop.c
+ *
+ *  Created on: Oct 19, 2016
+ *      Author: devel
+ */
+
+#include "arpop.h"
+
+static int arp_fd;
+
+int send_arp_request(char *ip, char *netint)
+{
+	int retVal;
+	libnet_t *l;
+	char errbuf[LIBNET_ERRBUF_SIZE], target_ip_addr_str[16];
+	unsigned int target_ip_addr, src_ip_addr;
+	unsigned char mac_broadcast_addr[MAC_LEN] = {0xff, 0xff, 0xff, 0xff,0xff, 0xff};
+	unsigned char mac_zero_addr[MAC_LEN] = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+	struct libnet_ether_addr *src_mac_addr;
+	char *ether_frame;
+
+	arp_fd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ARP));
+	if( arp_fd == -1 )
+	{
+		log_err_printf("ARP Socket: %s", strerror(errno));
+		return (-1);
+	}
+
+	ether_frame = malloc(IP_MAXPACKET);
+	if(ether_frame == NULL){
+		log_err_printf("Allocation error\n");
+		return (-1);
+	}
+
+	l = libnet_init(LIBNET_LINK, netint, errbuf);
+	if ( l == NULL ) {
+		log_err_printf("libnet_init() failed: %s\n", errbuf);
+		return (-1);
+	}
+
+	/* Getting our own MAC and IP addresses */
+
+	src_ip_addr = libnet_get_ipaddr4(l);
+	if ( src_ip_addr == -1 ) {
+		log_err_printf("Couldn't get own IP address: %s\n", libnet_geterror(l));
+		goto bad;
+	}
+
+	src_mac_addr = libnet_get_hwaddr(l);
+	if ( src_mac_addr == NULL ) {
+		log_err_printf("Couldn't get own MAC address: %s\n", libnet_geterror(l));
+		goto bad;
+	}
+
+	/* Getting target IP address */
+	target_ip_addr = libnet_name2addr4(l, ip, LIBNET_DONT_RESOLVE);
+
+	if ( target_ip_addr == -1 ) {
+		log_err_printf("Error converting IP address.\n");
+		goto bad;
+	}
+
+	/* Building ARP header */
+
+	if ( libnet_autobuild_arp (ARPOP_REQUEST,\
+							   src_mac_addr->ether_addr_octet,\
+							   (u_int8_t*)(&src_ip_addr), mac_zero_addr,\
+							   (u_int8_t*)(&target_ip_addr), l) == -1)
+	{
+		log_err_printf("Error building ARP header: %s\n", libnet_geterror(l));
+		goto bad;
+	}
+
+	/* Building Ethernet header */
+
+	if ( libnet_autobuild_ethernet (mac_broadcast_addr, ETHERTYPE_ARP, l) == -1 )
+	{
+		log_err_printf("Error building Ethernet header: %s\n", libnet_geterror(l));
+		goto bad;
+	}
+
+	/* Writing packet */
+
+	retVal = libnet_write(l);
+	if ( retVal == -1 ){
+		log_err_printf("Error writing packet: %s\n", libnet_geterror(l));
+		goto bad;
+	}
+
+	retVal = 0;
+bad:
+	libnet_destroy(l);
+	free (ether_frame);
+
+	return retVal;
+}
+
+int get_arp_response(char *ip, char mac[MAC_LEN])
+{
+
+    ARP_PKT *arphdr;
+	char *ether_frame;
+	int status;
+	int i = 0;
+	struct timeval tv;
+
+	ether_frame = malloc(IP_MAXPACKET);
+	if(ether_frame == NULL){
+		log_err_printf("Allocation error\n");
+		return (-1);
+	}
+
+
+	tv.tv_sec = 2;
+	tv.tv_usec = 0;
+
+	setsockopt(arp_fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv,sizeof(struct timeval));
+    arphdr = (ARP_PKT *) ether_frame;
+    do{
+        if ((status = recvfrom (arp_fd, ether_frame, IP_MAXPACKET, 0, NULL, NULL)) < 0) {
+            if (errno == EINTR) {
+                memset (ether_frame, 0, IP_MAXPACKET * sizeof (char));
+                continue;
+            }
+            else {
+               log_err_printf ("recv() failed: %s", strerror(errno));
+               close(arp_fd);
+               free(ether_frame);
+               return (-1);
+            }
+        }
+
+        if( ((ether_frame[12] << 8) + ether_frame[13]) != ETH_P_ARP ){
+        	continue;
+        }
+
+        if(ntohs (arphdr->arp_opcode) != ARPOP_REPLY){
+        	continue;
+        }
+    }while(inet_addr(ip) != arphdr->sender_ip );
+
+    memcpy(mac, arphdr->sender_mac, MAC_LEN);
+
+    close(arp_fd);
+    free(ether_frame);
+
+    return 0;
+}
+
+

--- a/arpop.h
+++ b/arpop.h
@@ -1,0 +1,58 @@
+/*
+ * arpop.h
+ *
+ *  Created on: Oct 19, 2016
+ *      Author: devel
+ */
+
+#ifndef ARPOP_H_
+#define ARPOP_H_
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <errno.h>
+#include <libnet.h>
+#include <net/ethernet.h>
+
+#define ARPOP_REPLY 2
+
+#define ETHER_TYPE_FOR_ARP 0x0806
+#define HW_TYPE_FOR_ETHER 0x0001
+#define OP_CODE_FOR_ARP_REQ 0x0001
+#define HW_LEN_FOR_ETHER 0x06
+#define HW_LEN_FOR_IP 0x04
+#define PROTO_TYPE_FOR_IP 0x0800
+
+#define MAC_LEN (6)
+
+#pragma pack(1)
+typedef struct arp_packet
+{
+    // ETH Header
+    char dest_mac[6];
+    char src_mac[6];
+    unsigned short ether_type;
+    // ARP Header
+    unsigned short hw_type;
+    unsigned short proto_type;
+    char hw_size;
+    char proto_size;
+    unsigned short arp_opcode;
+    char sender_mac[6];
+    unsigned int sender_ip;
+    char target_mac[6];
+    unsigned int target_ip;
+    char padding[18];
+}ARP_PKT;
+
+int get_arp_response(char *ip, char mac[MAC_LEN]);
+int send_arp_request(char *ip, char *netint);
+
+#endif /* ARPOP_H_ */

--- a/log.c
+++ b/log.c
@@ -265,6 +265,7 @@ log_connect_fini(void)
 
 struct log_content_ctx {
 	unsigned int open : 1;
+	unsigned int is_request;
 	union {
 		struct {
 			char *header_req;
@@ -278,6 +279,10 @@ struct log_content_ctx {
 			int fd;
 			char *filename;
 		} spec;
+		struct {
+			pcap_log_t * request;
+			pcap_log_t * response;
+		}pcap;
 	} u;
 };
 
@@ -512,86 +517,100 @@ log_content_open(log_content_ctx_t **pctx, opts_t *opts,
 		return -1;
 	ctx = *pctx;
 
-	if (opts->contentlog_isdir) {
-		/* per-connection-file content log (-S) */
-		char timebuf[24];
-		time_t epoch;
-		struct tm *utc;
-		char *dsthost_clean, *srchost_clean;
+	if(!opts->contentlog_pcap){
+		if (opts->contentlog_isdir) {
+			/* per-connection-file content log (-S) */
+			char timebuf[24];
+			time_t epoch;
+			struct tm *utc;
+			char *dsthost_clean, *srchost_clean;
 
-		if (time(&epoch) == -1) {
-			log_err_printf("Failed to get time\n");
-			goto errout;
-		}
-		if ((utc = gmtime(&epoch)) == NULL) {
-			log_err_printf("Failed to convert time: %s (%i)\n",
-			               strerror(errno), errno);
-			goto errout;
-		}
-		if (!strftime(timebuf, sizeof(timebuf),
-		              "%Y%m%dT%H%M%SZ", utc)) {
-			log_err_printf("Failed to format time: %s (%i)\n",
-			               strerror(errno), errno);
-			goto errout;
-		}
-		srchost_clean = sys_ip46str_sanitize(srchost);
-		if (!srchost_clean) {
-			log_err_printf("Failed to sanitize srchost\n");
-			goto errout;
-		}
-		dsthost_clean = sys_ip46str_sanitize(dsthost);
-		if (!dsthost_clean) {
-			log_err_printf("Failed to sanitize dsthost\n");
-			free(srchost_clean);
-			goto errout;
-		}
-		if (asprintf(&ctx->u.dir.filename, "%s/%s-%s,%s-%s,%s.log",
-		             opts->contentlog, timebuf,
-		             srchost_clean, srcport,
-		             dsthost_clean, dstport) < 0) {
-			log_err_printf("Failed to format filename: %s (%i)\n",
-			               strerror(errno), errno);
+			if (time(&epoch) == -1) {
+				log_err_printf("Failed to get time\n");
+				goto errout;
+			}
+			if ((utc = gmtime(&epoch)) == NULL) {
+				log_err_printf("Failed to convert time: %s (%i)\n",
+							   strerror(errno), errno);
+				goto errout;
+			}
+			if (!strftime(timebuf, sizeof(timebuf),
+						  "%Y%m%dT%H%M%SZ", utc)) {
+				log_err_printf("Failed to format time: %s (%i)\n",
+							   strerror(errno), errno);
+				goto errout;
+			}
+			srchost_clean = sys_ip46str_sanitize(srchost);
+			if (!srchost_clean) {
+				log_err_printf("Failed to sanitize srchost\n");
+				goto errout;
+			}
+			dsthost_clean = sys_ip46str_sanitize(dsthost);
+			if (!dsthost_clean) {
+				log_err_printf("Failed to sanitize dsthost\n");
+				free(srchost_clean);
+				goto errout;
+			}
+			if (asprintf(&ctx->u.dir.filename, "%s/%s-%s,%s-%s,%s.log",
+						 opts->contentlog, timebuf,
+						 srchost_clean, srcport,
+						 dsthost_clean, dstport) < 0) {
+				log_err_printf("Failed to format filename: %s (%i)\n",
+							   strerror(errno), errno);
+				free(srchost_clean);
+				free(dsthost_clean);
+				goto errout;
+			}
 			free(srchost_clean);
 			free(dsthost_clean);
-			goto errout;
-		}
-		free(srchost_clean);
-		free(dsthost_clean);
-	} else if (opts->contentlog_isspec) {
-		/* per-connection-file content log with logspec (-F) */
-		char *dsthost_clean, *srchost_clean;
-		srchost_clean = sys_ip46str_sanitize(srchost);
-		if (!srchost_clean) {
-			log_err_printf("Failed to sanitize srchost\n");
-			goto errout;
-		}
-		dsthost_clean = sys_ip46str_sanitize(dsthost);
-		if (!dsthost_clean) {
-			log_err_printf("Failed to sanitize dsthost\n");
+		} else if (opts->contentlog_isspec) {
+			/* per-connection-file content log with logspec (-F) */
+			char *dsthost_clean, *srchost_clean;
+			srchost_clean = sys_ip46str_sanitize(srchost);
+			if (!srchost_clean) {
+				log_err_printf("Failed to sanitize srchost\n");
+				goto errout;
+			}
+			dsthost_clean = sys_ip46str_sanitize(dsthost);
+			if (!dsthost_clean) {
+				log_err_printf("Failed to sanitize dsthost\n");
+				free(srchost_clean);
+				goto errout;
+			}
+			ctx->u.spec.filename = log_content_format_pathspec(
+												   opts->contentlog,
+												   srchost_clean, srcport,
+												   dsthost_clean, dstport,
+												   exec_path, user, group);
 			free(srchost_clean);
+			free(dsthost_clean);
+			if (!ctx->u.spec.filename) {
+				goto errout;
+			}
+		} else {
+			/* single-file content log (-L) */
+			if (asprintf(&ctx->u.file.header_req, "[%s]:%s -> [%s]:%s",
+						 srchost, srcport, dsthost, dstport) < 0) {
+				goto errout;
+			}
+			if (asprintf(&ctx->u.file.header_resp, "[%s]:%s -> [%s]:%s",
+						 dsthost, dstport, srchost, srcport) < 0) {
+				free(ctx->u.file.header_req);
+				goto errout;
+			}
+		}
+	}
+	else{
+		ctx->u.pcap.request = malloc(sizeof(pcap_log_t));
+		ctx->u.pcap.response = malloc(sizeof(pcap_log_t));
+
+		if(!ctx->u.pcap.request || !ctx->u.pcap.response){
+			free(ctx->u.pcap.request);
+			free(ctx->u.pcap.response);
 			goto errout;
 		}
-		ctx->u.spec.filename = log_content_format_pathspec(
-		                                       opts->contentlog,
-		                                       srchost_clean, srcport,
-		                                       dsthost_clean, dstport,
-		                                       exec_path, user, group);
-		free(srchost_clean);
-		free(dsthost_clean);
-		if (!ctx->u.spec.filename) {
-			goto errout;
-		}
-	} else {
-		/* single-file content log (-L) */
-		if (asprintf(&ctx->u.file.header_req, "[%s]:%s -> [%s]:%s",
-		             srchost, srcport, dsthost, dstport) < 0) {
-			goto errout;
-		}
-		if (asprintf(&ctx->u.file.header_resp, "[%s]:%s -> [%s]:%s",
-		             dsthost, dstport, srchost, srcport) < 0) {
-			free(ctx->u.file.header_req);
-			goto errout;
-		}
+		store_ip_port(ctx->u.pcap.request, srchost, srcport, dsthost, dstport);
+		store_ip_port(ctx->u.pcap.response, dsthost, dstport, srchost, srcport);
 	}
 
 	/* submit an open event */
@@ -856,6 +875,175 @@ out:
 	return lb;
 }
 
+static int
+pcap_dump_file_preinit(const char *logfile)
+{
+	content_file_fd = open(logfile, O_WRONLY|O_APPEND|O_CREAT,
+	                       DFLT_FILEMODE);
+	if (content_file_fd == -1) {
+		log_err_printf("Failed to open '%s' for writing: %s (%i)\n",
+		               logfile, strerror(errno), errno);
+		return -1;
+	}
+	if (!(content_file_fn = realpath(logfile, NULL))) {
+		log_err_printf("Failed to realpath '%s': %s (%i)\n",
+		              logfile, strerror(errno), errno);
+		close(content_file_fd);
+		connect_fd = -1;
+		return -1;
+	}
+
+	if(write_pcap_global_hdr(content_file_fd) == -1){
+		close(content_file_fd);
+		connect_fd = -1;
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+pcap_dump_file_reopencb(void)
+{
+	close(content_file_fd);
+	content_file_fd = open(content_file_fn,
+	                       O_WRONLY|O_APPEND|O_CREAT, DFLT_FILEMODE);
+	if (content_file_fd == -1) {
+		log_err_printf("Failed to open '%s' for writing: %s (%i)\n",
+		               content_file_fn, strerror(errno), errno);
+		return -1;
+	}
+	return 0;
+}
+
+static void
+pcap_dump_file_closecb(void *fh)
+{
+	log_content_ctx_t *ctx = fh;
+
+	if(ctx->u.pcap.request->seq > 0 && ctx->u.pcap.request->ack > 0){
+
+		if(build_ip_packet(content_file_fd, ctx->u.pcap.request, TH_FIN | TH_ACK, NULL, 0) == -1){
+			log_err_printf("Warning: Failed to write to content log: %s\n",
+			               strerror(errno));
+		}
+		ctx->u.pcap.response->ack += 1;
+		if(build_ip_packet(content_file_fd, ctx->u.pcap.response, TH_ACK, NULL, 0) == -1){
+			log_err_printf("Warning: Failed to write to content log: %s\n",
+			               strerror(errno));
+		}
+		if(build_ip_packet(content_file_fd, ctx->u.pcap.response, TH_FIN | TH_ACK, NULL, 0) == -1){
+			log_err_printf("Warning: Failed to write to content log: %s\n",
+			               strerror(errno));
+		}
+		ctx->u.pcap.request->ack += 1;
+		ctx->u.pcap.request->seq += 1;
+
+		if(build_ip_packet(content_file_fd, ctx->u.pcap.request, TH_ACK, NULL, 0) == -1){
+			log_err_printf("Warning: Failed to write to content log: %s\n",
+			               strerror(errno));
+		}
+	}
+	else{
+/*		if(build_ip_packet(content_file_fd, ctx->u.pcap.response, TH_FIN | TH_ACK, NULL, 0) == -1){
+			log_err_printf("Warning: Failed to write to content log: %s\n",
+			               strerror(errno));
+			return -1;
+		}
+	*/
+	}
+
+	if (ctx->u.pcap.request) {
+		free(ctx->u.pcap.request);
+	}
+	if (ctx->u.pcap.response) {
+		free(ctx->u.pcap.response);
+	}
+
+	free(ctx);
+}
+
+static ssize_t
+pcap_dump_file_writecb(void *fh, const void *buf, size_t sz)
+{
+	log_content_ctx_t *ctx = fh;
+	char flags = TH_PUSH | TH_ACK;
+
+	if(ctx->is_request){
+		if(ctx->u.pcap.request->seq == 0){
+			if(ctx->is_request){
+				if(build_ip_packet(content_file_fd, ctx->u.pcap.request, TH_SYN, NULL, 0) == -1){
+					log_err_printf("Warning: Failed to write to content log: %s\n",
+					               strerror(errno));
+					return -1;
+				}
+
+				ctx->u.pcap.response->ack = ctx->u.pcap.request->seq + 1;
+
+				if(build_ip_packet(content_file_fd, ctx->u.pcap.response, TH_SYN | TH_ACK, NULL, 0) == -1){
+					log_err_printf("Warning: Failed to write to content log: %s\n",
+					               strerror(errno));
+					return -1;
+				}
+
+				ctx->u.pcap.request->ack = ctx->u.pcap.response->seq + 1;
+				ctx->u.pcap.request->seq += 1;
+				if(build_ip_packet(content_file_fd, ctx->u.pcap.request, TH_ACK, NULL, 0) == -1){
+						log_err_printf("Warning: Failed to write to content log: %s\n",
+								               strerror(errno));
+						return -1;
+				}
+
+				ctx->u.pcap.response->seq += 1;
+			}
+		}
+
+		if(build_ip_packet(content_file_fd, ctx->u.pcap.request, flags, buf, sz) == -1){
+			log_err_printf("Warning: Failed to write to content log: %s\n",
+			               strerror(errno));
+			return -1;
+		}
+		ctx->u.pcap.response->ack += sz;
+	}
+	else{
+		if(build_ip_packet(content_file_fd, ctx->u.pcap.response, flags, buf, sz) == -1){
+			log_err_printf("Warning: Failed to write to content log: %s\n",
+			               strerror(errno));
+			return -1;
+		}
+		ctx->u.pcap.request->ack += sz;
+	}
+
+	return sz;
+}
+
+static logbuf_t *
+pcap_dump_file_prepcb(void *fh, unsigned long prepflags, logbuf_t *lb)
+{
+	log_content_ctx_t *ctx = fh;
+	int is_request = !!(prepflags & PREPFLAG_REQUEST);
+	time_t epoch;
+	struct tm *utc;
+	pcap_log_t *pcap = NULL;
+	logbuf_t *head = NULL;
+
+	ctx->is_request = is_request;
+
+/*	head = logbuf_new_alloc(sizeof(pcap_log_t), lb->fh, lb);
+	if (!head) {
+		log_err_printf("Failed to allocate memory\n");
+		logbuf_free(lb);
+		return NULL;
+	}
+
+	memcpy(head->buf, pcap, sizeof(pcap_log_t));
+
+	lb = head;
+*/
+out:
+
+	return lb;
+}
 
 /*
  * Certificate writer for -w/-W options.
@@ -929,26 +1117,37 @@ log_preinit(opts_t *opts)
 	logger_prep_func_t prepcb;
 
 	if (opts->contentlog) {
-		if (opts->contentlog_isdir) {
-			reopencb = NULL;
-			opencb = log_content_dir_opencb;
-			closecb = log_content_dir_closecb;
-			writecb = log_content_dir_writecb;
-			prepcb = NULL;
-		} else if (opts->contentlog_isspec) {
-			reopencb = NULL;
-			opencb = log_content_spec_opencb;
-			closecb = log_content_spec_closecb;
-			writecb = log_content_spec_writecb;
-			prepcb = NULL;
-		} else {
-			if (log_content_file_preinit(opts->contentlog) == -1)
+		if(!opts->contentlog_pcap){
+			if (opts->contentlog_isdir) {
+				reopencb = NULL;
+				opencb = log_content_dir_opencb;
+				closecb = log_content_dir_closecb;
+				writecb = log_content_dir_writecb;
+				prepcb = NULL;
+			} else if (opts->contentlog_isspec) {
+				reopencb = NULL;
+				opencb = log_content_spec_opencb;
+				closecb = log_content_spec_closecb;
+				writecb = log_content_spec_writecb;
+				prepcb = NULL;
+			} else {
+				if (log_content_file_preinit(opts->contentlog) == -1)
+					goto out;
+				reopencb = log_content_file_reopencb;
+				opencb = NULL;
+				closecb = log_content_file_closecb;
+				writecb = log_content_file_writecb;
+				prepcb = log_content_file_prepcb;
+			}
+		}
+		else{
+			if (pcap_dump_file_preinit(opts->contentlog) == -1)
 				goto out;
-			reopencb = log_content_file_reopencb;
+			reopencb = pcap_dump_file_reopencb;
 			opencb = NULL;
-			closecb = log_content_file_closecb;
-			writecb = log_content_file_writecb;
-			prepcb = log_content_file_prepcb;
+			closecb = pcap_dump_file_closecb;
+			writecb = pcap_dump_file_writecb;
+			prepcb = pcap_dump_file_prepcb;
 		}
 		if (!(content_log = logger_new(reopencb, opencb, closecb,
 		                               writecb, prepcb,

--- a/log.c
+++ b/log.c
@@ -878,6 +878,7 @@ out:
 static int
 pcap_dump_file_preinit(const char *logfile)
 {
+	unlink(logfile);
 	content_file_fd = open(logfile, O_WRONLY|O_APPEND|O_CREAT,
 	                       DFLT_FILEMODE);
 	if (content_file_fd == -1) {

--- a/log.c
+++ b/log.c
@@ -509,6 +509,7 @@ log_content_open(log_content_ctx_t **pctx, opts_t *opts,
                  char *exec_path, char *user, char *group)
 {
 	log_content_ctx_t *ctx;
+	char enet_dst[MAC_LEN] = {0x2B, 0xDE, 0x7C, 0x01, 0x7C, 0xA9};
 
 	if (*pctx)
 		return 0;
@@ -603,6 +604,15 @@ log_content_open(log_content_ctx_t **pctx, opts_t *opts,
 	else{
 		ctx->u.pcap.request = malloc(sizeof(pcap_log_t));
 		ctx->u.pcap.response = malloc(sizeof(pcap_log_t));
+
+		if(opts->mirrortarget != NULL && opts->contentlog_mirror != 0){
+			memcpy(ctx->u.pcap.request->target_mac, opts->target_mac, sizeof(opts->target_mac));
+			memcpy(ctx->u.pcap.response->target_mac, opts->target_mac, sizeof(opts->target_mac));
+		}
+		else{
+			memcpy(ctx->u.pcap.request->target_mac, enet_dst, sizeof(enet_dst));
+			memcpy(ctx->u.pcap.response->target_mac, enet_dst, sizeof(enet_dst));
+		}
 
 		if(!ctx->u.pcap.request || !ctx->u.pcap.response){
 			free(ctx->u.pcap.request);

--- a/log.c
+++ b/log.c
@@ -981,6 +981,7 @@ pcap_dump_file_writecb(void *fh, const void *buf, size_t sz)
 	log_content_ctx_t *ctx = fh;
 	char flags = TH_PUSH | TH_ACK;
 	void *iohandle = ctx->u.pcap.request->mirror ? content_file_fn : content_file_fd;
+	int sendsize = 0;
 
 	if(ctx->is_request){
 		if(ctx->u.pcap.request->seq == 0){
@@ -1011,20 +1012,18 @@ pcap_dump_file_writecb(void *fh, const void *buf, size_t sz)
 			}
 		}
 
-		if(build_ip_packet(iohandle, ctx->u.pcap.request, flags, buf, sz) == -1){
+		if(write_payload(iohandle, ctx->u.pcap.request, ctx->u.pcap.response, flags, buf, sz) == -1){
 			log_err_printf("Warning: Failed to write to content log: %s\n",
 			               strerror(errno));
 			return -1;
 		}
-		ctx->u.pcap.response->ack += sz;
 	}
 	else{
-		if(build_ip_packet(iohandle, ctx->u.pcap.response, flags, buf, sz) == -1){
+		if(write_payload(iohandle, ctx->u.pcap.response, ctx->u.pcap.request, flags, buf, sz) == -1){
 			log_err_printf("Warning: Failed to write to content log: %s\n",
 			               strerror(errno));
 			return -1;
 		}
-		ctx->u.pcap.request->ack += sz;
 	}
 
 	return sz;

--- a/log.h
+++ b/log.h
@@ -32,6 +32,7 @@
 #include "proxy.h"
 #include "logger.h"
 #include "attrib.h"
+#include "pcapfile.h"
 
 int log_err_printf(const char *, ...) PRINTF(1,2);
 void log_err_mode(int);

--- a/logbuf.h
+++ b/logbuf.h
@@ -29,6 +29,7 @@
 #define LOGBUF_H
 
 #include "attrib.h"
+#include "pcapfile.h"
 
 #include <stdlib.h>
 #include <unistd.h>

--- a/main.c
+++ b/main.c
@@ -173,6 +173,7 @@ main_usage(void)
 "  -p pidfile  write pid to pidfile (default: no pid file)\n"
 "  -l logfile  connect log: log one line summary per connection to logfile\n"
 "  -L logfile  content log: full data to file or named pipe (excludes -S/-F)\n"
+"  -X pcapfile Pcap Dump: full packet to file (some TCP/IP fields set as emulated value) (excludes -S/-F)\n"
 "  -S logdir   content log: full data to separate files in dir (excludes -L/-F)\n"
 "  -F pathspec content log: full data to sep files with %% subst (excl. -L/-S):\n"
 "              %%T - initial connection time as an ISO 8601 UTC timestamp\n"
@@ -303,7 +304,7 @@ main(int argc, char *argv[])
 	}
 
 	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z OPT_i "k:c:C:K:t:"
-	                    "OPs:r:R:e:Eu:m:j:p:l:L:S:F:dDVhW:w:")) != -1) {
+	                    "OPs:r:R:e:Eu:m:j:p:l:X:L:S:F:dDVhW:w:")) != -1) {
 		switch (ch) {
 			case 'c':
 				if (opts->cacrt)
@@ -552,6 +553,16 @@ main(int argc, char *argv[])
 					oom_die(argv0);
 				opts->contentlog_isdir = 0;
 				opts->contentlog_isspec = 0;
+				break;
+			case 'X':
+				if (opts->contentlog)
+					free(opts->contentlog);
+				opts->contentlog = strdup(optarg);
+				if (!opts->contentlog)
+					oom_die(argv0);
+				opts->contentlog_isdir = 0;
+				opts->contentlog_isspec = 0;
+				opts->contentlog_pcap = 1;
 				break;
 			case 'S':
 				if (!sys_isdir(optarg)) {

--- a/main.c
+++ b/main.c
@@ -712,10 +712,13 @@ main(int argc, char *argv[])
 	/* usage checks before defaults */
 
 	if(opts->mirrortarget != NULL && opts->contentlog_mirror != 0){
-		if(get_macaddr_of_mirror_ip(opts->mirrortarget, opts->target_mac, opts->contentlog) == -1){
-			log_err_printf("Target Mirroring error. Arp Response couldnt read!!\n");
-			exit(EXIT_FAILURE);
-		}
+		do{
+			rv = get_macaddr_of_mirror_ip(opts->mirrortarget, opts->target_mac, opts->contentlog);
+			if(rv == -1){
+				log_err_printf("Target Mirroring error. Arp Response couldnt read!!\n");
+				sleep(5);
+			}
+		}while(rv == -1);
 	}
 	else if (opts->mirrortarget != NULL && opts->contentlog_mirror == 0){
 		fprintf(stderr, "When target ip address is specified with -T option, "

--- a/main.c
+++ b/main.c
@@ -25,6 +25,20 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/* INFO BEFORE RUN
+ 
+ iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 8080
+ iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-ports 8443
+ 
+ sysctl -w net.ipv4.ip_forward=1
+ 
+ sudo /mnt/hgfs/sslsplit/sslsplit -u root -D -l connections.log -j ./tmp -X ./logs -k /mnt/hgfs/sslsplit/ca.key -c /mnt/hgfs/sslsplit/ca.crt   ssl 0.0.0.0 8443 tcp 0.0.0.0 8080
+ 
+ sudo /mnt/hgfs/sslsplit/sslsplit -u root -D -l connections.log -j ./tmp -M eth1 -k /mnt/hgfs/sslsplit/ca.key -c /mnt/hgfs/sslsplit/ca.crt   ssl 0.0.0.0 8443 tcp 0.0.0.0 8080
+ 
+ */
+
+
 /* silence daemon(3) deprecation warning on Mac OS X */
 #if __APPLE__
 #define daemon xdaemon

--- a/main.c
+++ b/main.c
@@ -174,6 +174,7 @@ main_usage(void)
 "  -l logfile  connect log: log one line summary per connection to logfile\n"
 "  -L logfile  content log: full data to file or named pipe (excludes -S/-F)\n"
 "  -X pcapfile Pcap Dump: full packet to file (some TCP/IP fields set as emulated value) (excludes -S/-F)\n"
+"  -X Interface Network Interface for mirroring (some TCP/IP fields set as emulated value) (excludes -S/-F)\n"
 "  -S logdir   content log: full data to separate files in dir (excludes -L/-F)\n"
 "  -F pathspec content log: full data to sep files with %% subst (excl. -L/-S):\n"
 "              %%T - initial connection time as an ISO 8601 UTC timestamp\n"
@@ -304,7 +305,7 @@ main(int argc, char *argv[])
 	}
 
 	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z OPT_i "k:c:C:K:t:"
-	                    "OPs:r:R:e:Eu:m:j:p:l:X:L:S:F:dDVhW:w:")) != -1) {
+	                    "OPs:r:R:e:Eu:m:j:p:l:X:M:L:S:F:dDVhW:w:")) != -1) {
 		switch (ch) {
 			case 'c':
 				if (opts->cacrt)
@@ -554,6 +555,8 @@ main(int argc, char *argv[])
 				opts->contentlog_isdir = 0;
 				opts->contentlog_isspec = 0;
 				break;
+			case 'M':
+				opts->contentlog_mirror = 1;
 			case 'X':
 				if (opts->contentlog)
 					free(opts->contentlog);

--- a/nat.c
+++ b/nat.c
@@ -338,6 +338,7 @@ nat_netfilter_lookup_cb(struct sockaddr *dst_addr, socklen_t *dst_addrlen,
 		log_err_printf("Error from getsockopt(SO_ORIGINAL_DST): %s\n",
 		               strerror(errno));
 	}
+
 	return rv;
 }
 

--- a/opts.h
+++ b/opts.h
@@ -32,6 +32,7 @@
 #include "nat.h"
 #include "ssl.h"
 #include "attrib.h"
+#include "arpop.h"
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -94,6 +95,8 @@ typedef struct opts {
 	char *connectlog;
 	char *contentlog;
 	char *contentlog_basedir; /* static part of logspec, for privsep srv */
+	char *mirrortarget;
+	char target_mac[MAC_LEN];
 	CONST_SSL_METHOD *(*sslmethod)(void);
 	X509 *cacrt;
 	EVP_PKEY *cakey;

--- a/opts.h
+++ b/opts.h
@@ -78,6 +78,7 @@ typedef struct opts {
 	unsigned int deny_ocsp : 1;
 	unsigned int contentlog_isdir : 1;
 	unsigned int contentlog_isspec : 1;
+	unsigned int contentlog_pcap:1;
 #ifdef HAVE_LOCAL_PROCINFO
 	unsigned int lprocinfo : 1;
 #endif /* HAVE_LOCAL_PROCINFO */

--- a/opts.h
+++ b/opts.h
@@ -79,6 +79,7 @@ typedef struct opts {
 	unsigned int contentlog_isdir : 1;
 	unsigned int contentlog_isspec : 1;
 	unsigned int contentlog_pcap:1;
+	unsigned int contentlog_mirror:1;
 #ifdef HAVE_LOCAL_PROCINFO
 	unsigned int lprocinfo : 1;
 #endif /* HAVE_LOCAL_PROCINFO */

--- a/pcapfile.c
+++ b/pcapfile.c
@@ -1,0 +1,170 @@
+#include "pcapfile.h"
+#include <errno.h>
+
+int
+write_pcap_global_hdr(int fd)
+{
+	pcap_hdr_t hdr;
+	int ret = 0;
+
+	memset(&hdr, 0x0, sizeof(hdr));
+
+	hdr.magic_number = 0xa1b2c3d4;
+	hdr.version_major = 2;
+	hdr.version_minor = 4;
+	hdr.snaplen = 1500;
+	hdr.network = 1;
+
+	ret = write(fd, &hdr, sizeof(hdr));
+	if(ret != sizeof(hdr)){
+		return -1;
+	}
+
+	return 0;
+}
+
+void
+store_ip_port(pcap_log_t *pcap, char* srcip, char *srcport, char * dstip, char *dstport)
+{
+	pcap->srcIp = inet_addr(srcip);
+	pcap->srcPort = atoi(srcport);
+	pcap->dstIp = inet_addr(dstip);
+	pcap->dstPort = atoi(dstport);
+	pcap->epoch = time(NULL);
+	pcap->seq = 0;
+	pcap->ack = 0;
+}
+
+int
+write_packet_into_file(libnet_t *l, int fd)
+{
+		int c;
+	    u_int32_t len;
+	    u_int8_t *packet = NULL;
+		pcaprec_hdr_t packet_record_hdr;
+		struct timeval tv;
+
+	    c = libnet_pblock_coalesce(l, &packet, &len);
+	    if (c == - 1){
+	        return (-1);
+	    }
+
+	    gettimeofday(&tv, NULL);
+
+	    packet_record_hdr.ts_sec = tv.tv_sec;
+	    packet_record_hdr.ts_usec = tv.tv_usec;
+	    packet_record_hdr.orig_len = packet_record_hdr.incl_len = len;
+
+	    c = write(fd, &packet_record_hdr, sizeof(packet_record_hdr));
+	    if(c == sizeof(packet_record_hdr)){
+			c = write(fd, packet, len);
+			if (c != len){
+				snprintf(l->err_buf, LIBNET_ERRBUF_SIZE,
+						"libnet_write_link(): only %d bytes written (%s)\n", c,
+						strerror(errno));
+				c = -1;
+
+			}
+	    }
+	    else{
+	    	c = -1;
+	    }
+
+	    if (l->aligner > 0)
+	    {
+	        packet = packet - l->aligner;
+	    }
+	    free(packet);
+
+	    libnet_clear_packet(l);
+
+	    return (c);
+}
+
+int
+build_ip_packet(int fd, pcap_log_t *pcap, char flags, char * payload, size_t payloadlen)
+{
+    char errbuf[LIBNET_ERRBUF_SIZE];
+    static libnet_t *l = NULL;
+    libnet_ptag_t t;
+    char enet_src[6] = {0x84,0x34,0xC3,0x50,0x68,0x8A};
+    char enet_dst[6] = {0x2B, 0xDE, 0x7C, 0x01, 0x7C, 0xA9};
+
+    if(l == NULL){
+		l = libnet_init(
+				LIBNET_LINK,                            /* injection type */
+				"lo",                                   /* network interface */
+				errbuf);                                /* error buffer */
+
+		if (l == NULL){
+			fprintf(stderr, "libnet_init() failed: %s", errbuf);
+			exit(EXIT_FAILURE);
+		}
+
+		libnet_seed_prand(l);
+   }
+
+    if(flags & TH_SYN){
+    	pcap->seq = libnet_get_prand(LIBNET_PRu32);
+    }
+
+    t = libnet_build_tcp(
+        pcap->srcPort,                                    /* source port */
+        pcap->dstPort,                                    /* destination port */
+		pcap->seq,                                 /* sequence number */
+        pcap->ack,                                 /* acknowledgement num */
+        flags,                                     /* control flags */
+        32767,                                      /* window size */
+        0,                                          /* checksum */
+        0,                                          /* urgent pointer */
+        LIBNET_TCP_H + payloadlen,              /* TCP packet size */
+	    payload,                                    /* payload */
+        payloadlen,                                  /* payload size */
+        l,                                          /* libnet handle */
+        0);                                         /* libnet id */
+    if (t == -1)
+    {
+        fprintf(stderr, "Can't build TCP header: %s\n", libnet_geterror(l));
+        goto bad;
+    }
+
+    t = libnet_build_ipv4(
+        LIBNET_IPV4_H + LIBNET_TCP_H + payloadlen,/* length */
+      	0,                                          /* TOS */
+		libnet_get_prand(LIBNET_PRu16),                                        /* IP ID */
+        0x4000,                                          /* IP Frag */
+        64,                                         /* TTL */
+        IPPROTO_TCP,                                /* protocol */
+        0,                                          /* checksum */
+        pcap->srcIp,                                     /* source IP */
+        pcap->dstIp,                                     /* destination IP */
+        NULL,                                       /* payload */
+        0,                                          /* payload size */
+        l,                                          /* libnet handle */
+        0);                                         /* libnet id */
+    if (t == -1){
+        fprintf(stderr, "Can't build IP header: %s\n", libnet_geterror(l));
+        goto bad;
+    }
+
+    t = libnet_build_ethernet(
+        enet_dst,                                   /* ethernet destination */
+        enet_src,                                   /* ethernet source */
+        ETHERTYPE_IP,                               /* protocol type */
+        NULL,                                       /* payload */
+        0,                                          /* payload size */
+        l,                                          /* libnet handle */
+        0);                                         /* libnet id */
+    if (t == -1){
+        fprintf(stderr, "Can't build ethernet header: %s\n", libnet_geterror(l));
+        goto bad;
+    }
+
+    pcap->seq += payloadlen;
+
+    return write_packet_into_file(l, fd);
+bad:
+	return -1;
+}
+
+

--- a/pcapfile.h
+++ b/pcapfile.h
@@ -1,0 +1,46 @@
+#ifndef __PCAP_FILE_H__
+#define __PCAP_FILE_H__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "libnet.h"
+
+typedef struct pcap_log{
+	time_t epoch;
+	unsigned int srcIp;
+	unsigned int dstIp;
+	unsigned short srcPort;
+	unsigned short dstPort;
+	unsigned int ack;
+	unsigned int seq;
+} pcap_log_t;
+
+
+typedef struct pcap_packet_header{
+	pcap_log_t packet_info;
+} packet_hdr_t;
+
+typedef struct pcap_hdr_s {
+        unsigned int magic_number;   /* magic number */
+        unsigned short version_major;  /* major version number */
+        unsigned short version_minor;  /* minor version number */
+        unsigned int  thiszone;       /* GMT to local correction */
+        unsigned int sigfigs;        /* accuracy of timestamps */
+        unsigned int snaplen;        /* max length of captured packets, in octets */
+        unsigned int network;        /* data link type */
+} pcap_hdr_t;
+
+typedef struct pcaprec_hdr_s {
+        unsigned int ts_sec;         /* timestamp seconds */
+        unsigned int ts_usec;        /* timestamp microseconds */
+        unsigned int incl_len;       /* number of octets of packet saved in file */
+        unsigned int orig_len;       /* actual length of packet */
+} pcaprec_hdr_t;
+
+
+void store_ip_port(pcap_log_t *, char* , char *, char * , char *);
+int build_ip_packet(int fd, pcap_log_t *pcap, char, char * payload, size_t payloadlen);
+int write_pcap_global_hdr(int fd);
+
+#endif

--- a/pcapfile.h
+++ b/pcapfile.h
@@ -4,9 +4,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include "libnet.h"
+#include <libnet.h>
+#include "arpop.h"
 
 #define MSS_VAL (1460)
+#define MIRROR_TO_INTERFACE (1)
+
 
 typedef struct pcap_log{
 	time_t epoch;
@@ -17,6 +20,7 @@ typedef struct pcap_log{
 	unsigned int ack;
 	unsigned int seq;
 	unsigned int mirror;
+	char target_mac[MAC_LEN];
 } pcap_log_t;
 
 
@@ -46,5 +50,6 @@ void store_ip_port(pcap_log_t *, char* , char *, char * , char *, int);
 int build_ip_packet(void * iohandle, pcap_log_t *pcap, char, char * payload, size_t payloadlen);
 int write_pcap_global_hdr(int fd);
 int write_payload(void *iohandle, pcap_log_t *from, pcap_log_t *to, char flags, char * payload, size_t payloadlen);
+int get_macaddr_of_mirror_ip(char *ip, char *mac, char *netint);
 
 #endif

--- a/pcapfile.h
+++ b/pcapfile.h
@@ -14,6 +14,7 @@ typedef struct pcap_log{
 	unsigned short dstPort;
 	unsigned int ack;
 	unsigned int seq;
+	unsigned int mirror;
 } pcap_log_t;
 
 
@@ -39,8 +40,8 @@ typedef struct pcaprec_hdr_s {
 } pcaprec_hdr_t;
 
 
-void store_ip_port(pcap_log_t *, char* , char *, char * , char *);
-int build_ip_packet(int fd, pcap_log_t *pcap, char, char * payload, size_t payloadlen);
+void store_ip_port(pcap_log_t *, char* , char *, char * , char *, int);
+int build_ip_packet(void * iohandle, pcap_log_t *pcap, char, char * payload, size_t payloadlen);
 int write_pcap_global_hdr(int fd);
 
 #endif

--- a/pcapfile.h
+++ b/pcapfile.h
@@ -6,6 +6,8 @@
 #include <time.h>
 #include "libnet.h"
 
+#define MSS_VAL (1460)
+
 typedef struct pcap_log{
 	time_t epoch;
 	unsigned int srcIp;
@@ -43,5 +45,6 @@ typedef struct pcaprec_hdr_s {
 void store_ip_port(pcap_log_t *, char* , char *, char * , char *, int);
 int build_ip_packet(void * iohandle, pcap_log_t *pcap, char, char * payload, size_t payloadlen);
 int write_pcap_global_hdr(int fd);
+int write_payload(void *iohandle, pcap_log_t *from, pcap_log_t *to, char flags, char * payload, size_t payloadlen);
 
 #endif


### PR DESCRIPTION
To dump as pcap format , just use -X [filename] parameter.
To mirror clear traffic to network interface, just use -M [interface]  parameter.
To mirror clear traffic to destination host, specify ip address of destination with -T [ip addr]. But destination host should be in same subnet
