### PR TITLE
remove _FORTIFY_SOURCE warning

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -347,7 +347,7 @@ endif
 
 CFLAGS+=	$(PKG_CFLAGS) \
 		-std=c99 -Wall -Wextra -pedantic \
-		-D_FORTIFY_SOURCE=2 -fstack-protector-all
+		-D_FORTIFY_SOURCE=2 -fstack-protector-all -O
 CPPFLAGS+=	$(PKG_CPPFLAGS) $(CPPDEFS) $(FEATURES)
 TCPPFLAGS+=	$(TPKG_CPPFLAGS)
 LDFLAGS+=	$(PKG_LDFLAGS)


### PR DESCRIPTION
This PR removes the #warning under Linux in `/usr/include/features.h` saying that  `_FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]`:

```
cc -c  -D_GNU_SOURCE -D"BNAME=\"sslsplit\"" -D"PNAME=\"SSLsplit\"" -D"VERSION=\"0.5.0-37-gab1c676\"" -D"BUILD_DATE=\"2016-10-26\"" -D"FEATURES=\"-DHAVE_NETFILTER\"" -D"BUILD_INFO=\"V:GIT\"" -DHAVE_NETFILTER -g -DOPENSSL_LOAD_CONF -pthread  -std=c99 -Wall -Wextra -pedantic -D_FORTIFY_SOURCE=2 -fstack-protector-all -pthread -o log.o log.c
In file included from /usr/include/sys/types.h:25:0,
                 from proc.h:33,
                 from opts.h:31,
                 from log.h:31,
                 from log.c:28:
/usr/include/features.h:341:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^
```

Don't know why `-O` or `-On` wasn't supplied in the first place. Alternatively  removal of `-D_FORTIFY_SOURCE=2` will achieve the same, I assume however that would not be in line w what you want...

Cheers, Dirk
