### PR TITLE
Feature/crl distrib point for forged certs

### DIFF
--- a/main.c
+++ b/main.c
@@ -139,6 +139,7 @@ main_usage(void)
 "  -K pemfile  use key from pemfile for leaf certs (default: generate)\n"
 "  -t certdir  use cert+chain+key PEM files from certdir to target all sites\n"
 "              matching the common names (non-matching: generate if CA)\n"
+"  -q crlurl   use this URL as CRL distrib point for all forged certs\n"
 "  -w gendir   write leaf key and only generated certificates to gendir\n"
 "  -W gendir   write leaf key and all certificates to gendir\n"
 "  -O          deny all OCSP requests on all proxyspecs\n"
@@ -303,7 +304,7 @@ main(int argc, char *argv[])
 	}
 
 	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z OPT_i "k:c:C:K:t:"
-	                    "OPs:r:R:e:Eu:m:j:p:l:L:S:F:dDVhW:w:")) != -1) {
+	                    "OPs:r:R:e:Eu:m:j:p:l:L:S:F:dDVhW:w:q:")) != -1) {
 		switch (ch) {
 			case 'c':
 				if (opts->cacrt)
@@ -413,6 +414,11 @@ main(int argc, char *argv[])
 				if (!opts->tgcrtdir)
 					oom_die(argv0);
 				break;
+            case 'q':
+                if (opts->crlurl)
+                    free(opts->crlurl);
+                opts->crlurl = strdup(optarg);
+                break;
 			case 'O':
 				opts->deny_ocsp = 1;
 				break;

--- a/main.c
+++ b/main.c
@@ -414,11 +414,11 @@ main(int argc, char *argv[])
 				if (!opts->tgcrtdir)
 					oom_die(argv0);
 				break;
-            case 'q':
-                if (opts->crlurl)
-                    free(opts->crlurl);
-                opts->crlurl = strdup(optarg);
-                break;
+			case 'q':
+				if (opts->crlurl)
+					free(opts->crlurl);
+				opts->crlurl = strdup(optarg);
+				break;
 			case 'O':
 				opts->deny_ocsp = 1;
 				break;

--- a/opts.h
+++ b/opts.h
@@ -104,6 +104,7 @@ typedef struct opts {
 	char *ecdhcurve;
 #endif /* !OPENSSL_NO_ECDH */
 	proxyspec_t *spec;
+	char *crlurl;
 } opts_t;
 
 opts_t *opts_new(void) MALLOC;

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -873,7 +873,7 @@ pxy_srccert_create(pxy_conn_ctx_t *ctx)
 			                           ctx->opts->cakey,
 			                           ctx->origcrt, NULL,
 			                           ctx->opts->key,
-									   ctx->opts->crlurl);
+			                           ctx->opts->crlurl);
 			cachemgr_fkcrt_set(ctx->origcrt, cert->crt);
 		}
 		cert_set_key(cert, ctx->opts->key);

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -872,7 +872,8 @@ pxy_srccert_create(pxy_conn_ctx_t *ctx)
 			cert->crt = ssl_x509_forge(ctx->opts->cacrt,
 			                           ctx->opts->cakey,
 			                           ctx->origcrt, NULL,
-			                           ctx->opts->key);
+			                           ctx->opts->key,
+									   ctx->opts->crlurl);
 			cachemgr_fkcrt_set(ctx->origcrt, cert->crt);
 		}
 		cert_set_key(cert, ctx->opts->key);
@@ -1019,7 +1020,7 @@ pxy_ossl_servername_cb(SSL *ssl, UNUSED int *al, void *arg)
 			               "(SNI mismatch)\n");
 		}
 		newcrt = ssl_x509_forge(ctx->opts->cacrt, ctx->opts->cakey,
-		                        sslcrt, sn, ctx->opts->key);
+		                        sslcrt, sn, ctx->opts->key, ctx->opts->crlurl);
 		if (!newcrt) {
 			ctx->enomem = 1;
 			return SSL_TLSEXT_ERR_NOACK;

--- a/ssl.c
+++ b/ssl.c
@@ -775,7 +775,7 @@ ssl_x509_serial_copyrand(X509 *dstcrt, X509 *srccrt)
  */
 X509 *
 ssl_x509_forge(X509 *cacrt, EVP_PKEY *cakey, X509 *origcrt,
-               const char *extraname, EVP_PKEY *key)
+               const char *extraname, EVP_PKEY *key, const char *crlurl)
 {
 	X509_NAME *subject, *issuer;
 	GENERAL_NAMES *names;
@@ -815,6 +815,14 @@ ssl_x509_forge(X509 *cacrt, EVP_PKEY *cakey, X509 *origcrt,
 	    ssl_x509_v3ext_add(&ctx, crt, "authorityKeyIdentifier",
 	                                  "keyid,issuer:always") == -1)
 		goto errout;
+
+	if (crlurl) {
+        char *crlurlval;
+        if (asprintf(&crlurlval, "URI:%s", crlurl) < 0)
+            goto errout;
+        if (ssl_x509_v3ext_add(&ctx, crt, "crlDistributionPoints", crlurlval) == -1) goto errout;
+    }
+
 
 	if (!extraname) {
 		/* no extraname provided: copy original subjectAltName ext */

--- a/ssl.c
+++ b/ssl.c
@@ -817,11 +817,11 @@ ssl_x509_forge(X509 *cacrt, EVP_PKEY *cakey, X509 *origcrt,
 		goto errout;
 
 	if (crlurl) {
-        char *crlurlval;
-        if (asprintf(&crlurlval, "URI:%s", crlurl) < 0)
-            goto errout;
-        if (ssl_x509_v3ext_add(&ctx, crt, "crlDistributionPoints", crlurlval) == -1) goto errout;
-    }
+		char *crlurlval;
+		if (asprintf(&crlurlval, "URI:%s", crlurl) < 0)
+			goto errout;
+		if (ssl_x509_v3ext_add(&ctx, crt, "crlDistributionPoints", crlurlval) == -1) goto errout;
+	}
 
 
 	if (!extraname) {

--- a/ssl.h
+++ b/ssl.h
@@ -171,7 +171,7 @@ int ssl_x509_v3ext_add(X509V3_CTX *, X509 *, char *, char *) NONNULL(1,2,3,4);
 int ssl_x509_v3ext_copy_by_nid(X509 *, X509 *, int) NONNULL(1,2);
 #endif /* !OPENSSL_NO_TLSEXT */
 int ssl_x509_serial_copyrand(X509 *, X509 *) NONNULL(1,2);
-X509 * ssl_x509_forge(X509 *, EVP_PKEY *, X509 *, const char *, EVP_PKEY *)
+X509 * ssl_x509_forge(X509 *, EVP_PKEY *, X509 *, const char *, EVP_PKEY *, const char *)
        NONNULL(1,2,3,5) MALLOC;
 X509 * ssl_x509_load(const char *) NONNULL(1) MALLOC;
 char * ssl_x509_subject(X509 *) NONNULL(1) MALLOC;


### PR DESCRIPTION
Many windows (especially .NET) applications require certificate to have possibility to validate against a revoke certificates list.

Currently we can only precraft certs with CRL in it for specific CNs. With a new option we can add CRL URL to every forged certificate.

You can check this for details: http://antalos.com/en/Development/decrypting-SSL-traffic-of-net-applications.php