### PR TITLE
Check retval of bufferevent_openssl_filter_new()

### DIFF
--- a/pxyconn.c
+++ b/pxyconn.c
@@ -1839,10 +1839,12 @@ pxy_bev_eventcb(struct bufferevent *bev, short events, void *arg)
 			               ctx->evbase, ctx->src.bev, ctx->src.ssl,
 			               BUFFEREVENT_SSL_ACCEPTING,
 			               BEV_OPT_DEFER_CALLBACKS);
-			bufferevent_setcb(ctx->src.bev, pxy_bev_readcb,
+			if (!ctx->src.bev) {
+				bufferevent_setcb(ctx->src.bev, pxy_bev_readcb,
 			                  pxy_bev_writecb, pxy_bev_eventcb,
 			                  ctx);
-			bufferevent_enable(ctx->src.bev, EV_READ|EV_WRITE);
+				bufferevent_enable(ctx->src.bev, EV_READ|EV_WRITE);
+			}
 		} else {
 			ctx->src.bev = pxy_bufferevent_setup(ctx, ctx->fd,
 			                                     ctx->src.ssl);

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -1839,7 +1839,7 @@ pxy_bev_eventcb(struct bufferevent *bev, short events, void *arg)
 			               ctx->evbase, ctx->src.bev, ctx->src.ssl,
 			               BUFFEREVENT_SSL_ACCEPTING,
 			               BEV_OPT_DEFER_CALLBACKS);
-			if (!ctx->src.bev) {
+			if (ctx->src.bev) {
 				bufferevent_setcb(ctx->src.bev, pxy_bev_readcb,
 			                  pxy_bev_writecb, pxy_bev_eventcb,
 			                  ctx);


### PR DESCRIPTION
Not the best pull request perhaps, because a few lines below we have to check again, but the sslsplit code I have reviewed always checks for such retvals. Any reason that this retval was left out?