### PR TITLE
Use -S for /tmp rather then -L in man page examples

### DIFF
--- a/sslsplit.1
+++ b/sslsplit.1
@@ -615,7 +615,7 @@ connection data into separate files under \fB/tmp\fP (add \fB-e\fP
 available on your system):
 .LP
 .nf
-\fBsslsplit -k ca.key -c ca.crt -l connect.log -L /tmp \\
+\fBsslsplit -k ca.key -c ca.crt -l connect.log -S /tmp \\
          https ::1 10443  https 127.0.0.1 10443 \\
          http  ::1 10080  http  127.0.0.1 10080\fP
 .fi
@@ -628,7 +628,7 @@ connections.
 Intercepting IMAP/IMAPS using the same settings:
 .LP
 .nf
-\fBsslsplit -k ca.key -c ca.crt -l connect.log -L /tmp \\
+\fBsslsplit -k ca.key -c ca.crt -l connect.log -S /tmp \\
          ssl ::1 10993  ssl 127.0.0.1 10993 \\
          tcp ::1 10143  tcp 127.0.0.1 10143\fP
 .fi
@@ -638,7 +638,7 @@ A more targetted setup, HTTPS only, using certificate/chain/key files from
 instead of querying a NAT engine:
 .LP
 .nf
-\fBsslsplit -t /path/to/cert.d -l connect.log -L /tmp \\
+\fBsslsplit -t /path/to/cert.d -l connect.log -S /tmp \\
          https ::1       10443 www.example.org 443 \\
          https 127.0.0.1 10443 www.example.org 443\fP
 .fi
@@ -654,7 +654,7 @@ suites they consider weak.
 .LP
 .nf
 \fBsslsplit -Z -s NULL:RC4:AES128:-DHE -K leaf.key \\
-         -k ca.key -c ca.crt -l connect.log -L /tmp \\
+         -k ca.key -c ca.crt -l connect.log -S /tmp \\
          https ::1 10443  https 127.0.0.1 10443 \\
          http  ::1 10080  http  127.0.0.1 10080\fP
 .fi
@@ -664,7 +664,7 @@ writing a PID file:
 .LP
 .nf
 \fBsslsplit -d -p /var/run/sslsplit.pid -u sslsplit \\
-         -k ca.key -c ca.crt -l connect.log -L /tmp \\
+         -k ca.key -c ca.crt -l connect.log -S /tmp \\
          https ::1 10443  https 127.0.0.1 10443 \\
          http  ::1 10080  http  127.0.0.1 10080\fP
 .fi


### PR DESCRIPTION
Parameter -S expects directory, but -L expects file.