### PR TITLE
Fix issue #183: Use SSL_CTX_set_min_proto_version() and SSL_CTX_set_m…

### DIFF
--- a/opts.h
+++ b/opts.h
@@ -95,6 +95,9 @@ typedef struct opts {
 	char *contentlog_basedir; /* static part of logspec, for privsep srv */
 	char *masterkeylog;
 	CONST_SSL_METHOD *(*sslmethod)(void);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	int sslversion;
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 	X509 *cacrt;
 	EVP_PKEY *cakey;
 	EVP_PKEY *key;

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -725,6 +725,16 @@ pxy_srcsslctx_create(pxy_conn_ctx_t *ctx, X509 *crt, STACK_OF(X509) *chain,
 
 	pxy_sslctx_setoptions(sslctx, ctx);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	if (ctx->opts->sslversion) {
+		if (SSL_CTX_set_min_proto_version(sslctx, ctx->opts->sslversion) == 0 ||
+			SSL_CTX_set_max_proto_version(sslctx, ctx->opts->sslversion) == 0) {
+			SSL_CTX_free(sslctx);
+			return NULL;
+		}
+	}
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+
 	SSL_CTX_sess_set_new_cb(sslctx, pxy_ossl_sessnew_cb);
 	SSL_CTX_sess_set_remove_cb(sslctx, pxy_ossl_sessremove_cb);
 	SSL_CTX_sess_set_get_cb(sslctx, pxy_ossl_sessget_cb);
@@ -1113,6 +1123,17 @@ pxy_dstssl_create(pxy_conn_ctx_t *ctx)
 	}
 
 	pxy_sslctx_setoptions(sslctx, ctx);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	if (ctx->opts->sslversion) {
+		if (SSL_CTX_set_min_proto_version(sslctx, ctx->opts->sslversion) == 0 ||
+			SSL_CTX_set_max_proto_version(sslctx, ctx->opts->sslversion) == 0) {
+			SSL_CTX_free(sslctx);
+			ctx->enomem = 1;
+			return NULL;
+		}
+	}
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 
 	SSL_CTX_set_verify(sslctx, SSL_VERIFY_NONE, NULL);
 


### PR DESCRIPTION
Per your suggestion, I have checked the latest source code of the openssl s_client utility. I see that they use those min/max functions to force protocol version. What do you think?