### PR TITLE
Add support for client certificates

### DIFF
--- a/main.c
+++ b/main.c
@@ -128,6 +128,8 @@ main_usage(void)
 "Usage: %s [options...] [proxyspecs...]\n"
 "  -c pemfile  use CA cert (and key) from pemfile to sign forged certs\n"
 "  -k pemfile  use CA key (and cert) from pemfile to sign forged certs\n"
+"  -a pemfile  use cert from pemfile when destination requests client certs\n"
+"  -b pemfile  use key from pemfile when destination requests client certs\n"
 "  -C pemfile  use CA chain from pemfile (intermediate and root CA certs)\n"
 "  -K pemfile  use key from pemfile for leaf certs (default: generate)\n"
 "  -q crlurl   use URL as CRL distribution point for all forged certs\n"
@@ -307,7 +309,7 @@ main(int argc, char *argv[])
 		natengine = NULL;
 	}
 
-	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z OPT_i "k:c:C:K:t:"
+	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z OPT_i "k:c:a:b:C:K:t:"
 	                    "OPs:r:R:e:Eu:m:j:p:l:L:S:F:M:dDVhW:w:q:")) != -1) {
 		switch (ch) {
 			case 'c':
@@ -367,6 +369,40 @@ main(int argc, char *argv[])
 					opts->dh = ssl_dh_load(optarg);
 				}
 #endif /* !OPENSSL_NO_DH */
+				break;
+			case 'a': //client cert
+                                if (opts->clientcrt)
+                                        X509_free(opts->clientcrt);
+                                opts->clientcrt = ssl_x509_load(optarg);
+                                if (!opts->clientcrt) {
+                                        fprintf(stderr, "%s: error loading client "
+                                                        "cert from '%s':\n",
+                                                        argv0, optarg);
+                                        if (errno) {
+                                                fprintf(stderr, "%s\n",
+                                                        strerror(errno));
+                                        } else {
+                                                ERR_print_errors_fp(stderr);
+                                        }
+                                        exit(EXIT_FAILURE);
+                                }
+				break;
+			case 'b': //client key
+                                if (opts->clientkey)
+                                        EVP_PKEY_free(opts->clientkey);
+                                opts->clientkey = ssl_key_load(optarg);
+                                if (!opts->clientkey) {
+                                        fprintf(stderr, "%s: error loading client "
+                                                        "key from '%s':\n",
+                                                        argv0, optarg);
+                                        if (errno) {
+                                                fprintf(stderr, "%s\n",
+                                                        strerror(errno));
+                                        } else {
+                                                ERR_print_errors_fp(stderr);
+                                        }
+                                        exit(EXIT_FAILURE);
+                                }
 				break;
 			case 'C':
 				if (ssl_x509chain_load(NULL, &opts->chain,

--- a/opts.h
+++ b/opts.h
@@ -100,6 +100,8 @@ typedef struct opts {
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 	X509 *cacrt;
 	EVP_PKEY *cakey;
+	X509 *clientcrt;
+	EVP_PKEY *clientkey;
 	EVP_PKEY *key;
 	STACK_OF(X509) *chain;
 #ifndef OPENSSL_NO_DH

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -1137,6 +1137,15 @@ pxy_dstssl_create(pxy_conn_ctx_t *ctx)
 
 	SSL_CTX_set_verify(sslctx, SSL_VERIFY_NONE, NULL);
 
+	if (ctx->opts->clientcrt) {
+		if (!SSL_CTX_use_certificate(sslctx, ctx->opts->clientcrt))
+			log_dbg_printf("loading client certificate failed");
+	}
+	if (ctx->opts->clientkey) {
+		if (!SSL_CTX_use_PrivateKey(sslctx, ctx->opts->clientkey))
+			log_dbg_printf("loading client key failed");
+	}
+
 	ssl = SSL_new(sslctx);
 	SSL_CTX_free(sslctx); /* SSL_new() increments refcount */
 	if (!ssl) {

--- a/sslsplit.1
+++ b/sslsplit.1
@@ -30,15 +30,15 @@ sslsplit \-\- transparent SSL/TLS interception
 .SH SYNOPSIS
 .na
 .B sslsplit
-[\fB-kCKqwWOPZdDgGsrReumjplLSFiM\fP] \fB-c\fP \fIpem\fP
+[\fB-kCKqwWOPZdDgGsrReumjplLSFiMab\fP] \fB-c\fP \fIpem\fP
 \fIproxyspecs\fP [...]
 .br
 .B sslsplit
-[\fB-kCKqwWOPZdDgGsrReumjplLSFiM\fP] \fB-c\fP \fIpem\fP \fB-t\fP \fIdir\fP
+[\fB-kCKqwWOPZdDgGsrReumjplLSFiMab\fP] \fB-c\fP \fIpem\fP \fB-t\fP \fIdir\fP
 \fIproxyspecs\fP [...]
 .br
 .B sslsplit
-[\fB-OPZwWdDgGsrReumjplLSFiM\fP] \fB-t\fP \fIdir\fP
+[\fB-OPZwWdDgGsrReumjplLSFiMab\fP] \fB-t\fP \fIdir\fP
 \fIproxyspecs\fP [...]
 .br
 .B sslsplit -E
@@ -104,6 +104,12 @@ legitimate router, ARP spoofing, ND spoofing, DNS poisoning, deploying a rogue
 access point (e.g. using hostap mode), physical recabling, malicious VLAN
 reconfiguration or route injection, /etc/hosts modification and so on.
 .SH OPTIONS
+.TP
+.B \-a \fIpemfile\fP
+Use client certificate from \fIpemfile\fP when destination server requests a client certificate
+.TP
+.B \-b \fIpemfile\fP
+Use client private key from \fIpemfile\fP when destination server requests a client certificate
 .TP
 .B \-c \fIpemfile\fP
 Use CA certificate from \fIpemfile\fP to sign certificates forged on-the-fly.


### PR DESCRIPTION
For #46, add initial support for providing client certificates when requested by the destination server.
Cert and private key are specified as command line args.
