### PR TITLE
Add fall through comment for missing break in case statement

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -421,13 +421,18 @@ install: $(TARGET)
 	test -d $(DESTDIR)$(PREFIX)/bin || $(MKDIR) -p $(DESTDIR)$(PREFIX)/bin
 	test -d $(DESTDIR)$(PREFIX)/$(MANDIR)/man1 || \
 		$(MKDIR) -p $(DESTDIR)$(PREFIX)/$(MANDIR)/man1
+	test -d $(DESTDIR)$(PREFIX)/$(MANDIR)/man5 || \
+		$(MKDIR) -p $(DESTDIR)$(PREFIX)/$(MANDIR)/man5
 	$(INSTALL) $(BINOWNERFLAGS) -m $(BINMODE) \
 		$(TARGET) $(DESTDIR)$(PREFIX)/bin/
 	$(INSTALL) $(MANOWNERFLAGS) -m $(MANMODE) \
 		$(TARGET).1 $(DESTDIR)$(PREFIX)/$(MANDIR)/man1/
+	$(INSTALL) $(MANOWNERFLAGS) -m $(MANMODE) \
+		$(TARGET).conf.5 $(DESTDIR)$(PREFIX)/$(MANDIR)/man5/
 
 deinstall:
-	$(RM) -f $(DESTDIR)$(PREFIX)/bin/$(TARGET) $(DESTDIR)$(PREFIX)/$(MANDIR)/man1/$(TARGET).1
+	$(RM) -f $(DESTDIR)$(PREFIX)/bin/$(TARGET) $(DESTDIR)$(PREFIX)/$(MANDIR)/man1/$(TARGET).1 \
+		$(DESTDIR)$(PREFIX)/$(MANDIR)/man5/$(TARGET).conf.5
 
 ifdef GITDIR
 lint:

--- a/main.c
+++ b/main.c
@@ -352,10 +352,10 @@ main(int argc, char *argv[])
 				opts_set_ciphers(opts, argv0, optarg);
 				break;
 			case 'r':
-				opts_proto_force(opts, optarg, argv0);
+				opts_force_proto(opts, argv0, optarg);
 				break;
 			case 'R':
-				opts_proto_disable(opts, optarg, argv0);
+				opts_disable_proto(opts, argv0, optarg);
 				break;
 			case 'e':
 				if (natengine)

--- a/main.c
+++ b/main.c
@@ -428,7 +428,7 @@ main(int argc, char *argv[])
 	}
 	argc -= optind;
 	argv += optind;
-	proxyspec_parse(&argc, &argv, natengine, opts);
+	proxyspec_parse(&argc, &argv, natengine, &opts->spec);
 	
 	if (opts->conffile) {
 		if (load_conffile(opts, argv0, natengine) == -1) {

--- a/nat.h
+++ b/nat.h
@@ -36,6 +36,9 @@
 
 #include <event2/util.h>
 
+// The longest natengine is "netfilter"
+#define NATENGINE_SIZE 10
+
 typedef int (*nat_lookup_cb_t)(struct sockaddr *, socklen_t *, evutil_socket_t,
                                struct sockaddr *, socklen_t);
 typedef int (*nat_socket_cb_t)(evutil_socket_t);

--- a/opts.c
+++ b/opts.c
@@ -234,7 +234,7 @@ opts_proto_dbg_dump(opts_t *opts)
  * Parse proxyspecs using a simple state machine.
  */
 void
-proxyspec_parse(int *argc, char **argv[], const char *natengine, opts_t *opts)
+proxyspec_parse(int *argc, char **argv[], const char *natengine, proxyspec_t **opts_spec)
 {
 	proxyspec_t *spec = NULL;
 	char *addr = NULL;
@@ -248,8 +248,8 @@ proxyspec_parse(int *argc, char **argv[], const char *natengine, opts_t *opts)
 				/* tcp | ssl | http | https | autossl */
 				spec = malloc(sizeof(proxyspec_t));
 				memset(spec, 0, sizeof(proxyspec_t));
-				spec->next = opts->spec;
-				opts->spec = spec;
+				spec->next = *opts_spec;
+				*opts_spec = spec;
 
 				// Defaults
 				spec->ssl = 0;
@@ -1270,7 +1270,7 @@ load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 				}
 			}
 			
-			proxyspec_parse(&argc, &argv, natengine, opts);
+			proxyspec_parse(&argc, &argv, natengine, &opts->spec);
 			free(save_argv);
 		} else {
 			fprintf(stderr, "Unknown option '%s' at %s line %d\n", name, opts->conffile, line_num);

--- a/opts.c
+++ b/opts.c
@@ -1084,13 +1084,13 @@ load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 	char *line, *name;
 	char natengine[NATENGINE_SIZE];
 	
-	strncpy(natengine, prev_natengine, NATENGINE_SIZE);
-
 	f = fopen(opts->conffile, "r");
 	if (!f) {
 		fprintf(stderr, "Error opening conf file %s: %s\n", opts->conffile, strerror(errno));
 		return -1;
 	}
+
+	strncpy(natengine, prev_natengine, NATENGINE_SIZE);
 
 	line = NULL;
 	line_num = 0;
@@ -1101,7 +1101,7 @@ load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 			break;
 		}
 		if (line == NULL) {
-			fprintf(stderr, "Error getline() buf=NULL");
+			fprintf(stderr, "Error in getline() line=NULL after line %d\n", line_num);
 			goto leave;
 		}
 		line_num++;
@@ -1130,7 +1130,7 @@ load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 
 		// No value
 		if (n == NULL) {
-			fprintf(stderr, "Conf error at line %d\n", line_num);
+			fprintf(stderr, "Error in conf file at line %d\n", line_num);
 			goto leave;
 		}
 		

--- a/opts.c
+++ b/opts.c
@@ -40,6 +40,18 @@
 #endif /* !OPENSSL_NO_DH */
 #include <openssl/x509.h>
 
+/*
+ * Handle out of memory conditions in early stages of main().
+ * Print error message and exit with failure status code.
+ * Does not return.
+ */
+void NORET
+oom_die(const char *argv0)
+{
+	fprintf(stderr, "%s: out of memory\n", argv0);
+	exit(EXIT_FAILURE);
+}
+
 opts_t *
 opts_new(void)
 {
@@ -158,121 +170,6 @@ opts_has_dns_spec(opts_t *opts)
 }
 
 /*
- * Parse SSL proto string in optarg and look up the corresponding SSL method.
- * Calls exit() on failure.
- */
-void
-opts_proto_force(opts_t *opts, const char *optarg, const char *argv0)
-{
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-	if (opts->sslmethod != SSLv23_method) {
-#else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
-	if (opts->sslversion) {
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
-		fprintf(stderr, "%s: cannot use -r multiple times\n", argv0);
-		exit(EXIT_FAILURE);
-	}
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#ifdef HAVE_SSLV2
-	if (!strcmp(optarg, "ssl2")) {
-		opts->sslmethod = SSLv2_method;
-	} else
-#endif /* HAVE_SSLV2 */
-#ifdef HAVE_SSLV3
-	if (!strcmp(optarg, "ssl3")) {
-		opts->sslmethod = SSLv3_method;
-	} else
-#endif /* HAVE_SSLV3 */
-#ifdef HAVE_TLSV10
-	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
-		opts->sslmethod = TLSv1_method;
-	} else
-#endif /* HAVE_TLSV10 */
-#ifdef HAVE_TLSV11
-	if (!strcmp(optarg, "tls11")) {
-		opts->sslmethod = TLSv1_1_method;
-	} else
-#endif /* HAVE_TLSV11 */
-#ifdef HAVE_TLSV12
-	if (!strcmp(optarg, "tls12")) {
-		opts->sslmethod = TLSv1_2_method;
-	} else
-#endif /* HAVE_TLSV12 */
-#else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
-/*
- * Support for SSLv2 and the corresponding SSLv2_method(),
- * SSLv2_server_method() and SSLv2_client_method() functions were
- * removed in OpenSSL 1.1.0.
- */
-#ifdef HAVE_SSLV3
-	if (!strcmp(optarg, "ssl3")) {
-		opts->sslversion = SSL3_VERSION;
-	} else
-#endif /* HAVE_SSLV3 */
-#ifdef HAVE_TLSV10
-	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
-		opts->sslversion = TLS1_VERSION;
-	} else
-#endif /* HAVE_TLSV10 */
-#ifdef HAVE_TLSV11
-	if (!strcmp(optarg, "tls11")) {
-		opts->sslversion = TLS1_1_VERSION;
-	} else
-#endif /* HAVE_TLSV11 */
-#ifdef HAVE_TLSV12
-	if (!strcmp(optarg, "tls12")) {
-		opts->sslversion = TLS1_2_VERSION;
-	} else
-#endif /* HAVE_TLSV12 */
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
-	{
-		fprintf(stderr, "%s: Unsupported SSL/TLS protocol '%s'\n",
-		                argv0, optarg);
-		exit(EXIT_FAILURE);
-	}
-}
-
-/*
- * Parse SSL proto string in optarg and set the corresponding no_foo bit.
- * Calls exit() on failure.
- */
-void
-opts_proto_disable(opts_t *opts, const char *optarg, const char *argv0)
-{
-#ifdef HAVE_SSLV2
-	if (!strcmp(optarg, "ssl2")) {
-		opts->no_ssl2 = 1;
-	} else
-#endif /* HAVE_SSLV2 */
-#ifdef HAVE_SSLV3
-	if (!strcmp(optarg, "ssl3")) {
-		opts->no_ssl3 = 1;
-	} else
-#endif /* HAVE_SSLV3 */
-#ifdef HAVE_TLSV10
-	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
-		opts->no_tls10 = 1;
-	} else
-#endif /* HAVE_TLSV10 */
-#ifdef HAVE_TLSV11
-	if (!strcmp(optarg, "tls11")) {
-		opts->no_tls11 = 1;
-	} else
-#endif /* HAVE_TLSV11 */
-#ifdef HAVE_TLSV12
-	if (!strcmp(optarg, "tls12")) {
-		opts->no_tls12 = 1;
-	} else
-#endif /* HAVE_TLSV12 */
-	{
-		fprintf(stderr, "%s: Unsupported SSL/TLS protocol '%s'\n",
-		                argv0, optarg);
-		exit(EXIT_FAILURE);
-	}
-}
-
-/*
  * Dump the SSL/TLS protocol related configuration to the debug log.
  */
 void
@@ -335,12 +232,11 @@ opts_proto_dbg_dump(opts_t *opts)
 
 /*
  * Parse proxyspecs using a simple state machine.
- * Returns NULL if parsing failed.
  */
-proxyspec_t *
-proxyspec_parse(int *argc, char **argv[], const char *natengine)
+void
+proxyspec_parse(int *argc, char **argv[], const char *natengine, opts_t *opts)
 {
-	proxyspec_t *curspec, *spec = NULL;
+	proxyspec_t *spec = NULL;
 	char *addr = NULL;
 	int af = AF_UNSPEC;
 	int state = 0;
@@ -350,33 +246,29 @@ proxyspec_parse(int *argc, char **argv[], const char *natengine)
 			default:
 			case 0:
 				/* tcp | ssl | http | https | autossl */
-				curspec = malloc(sizeof(proxyspec_t));
-				memset(curspec, 0, sizeof(proxyspec_t));
-				curspec->next = spec;
-				spec = curspec;
+				spec = malloc(sizeof(proxyspec_t));
+				memset(spec, 0, sizeof(proxyspec_t));
+				spec->next = opts->spec;
+				opts->spec = spec;
+
+				// Defaults
+				spec->ssl = 0;
+				spec->http = 0;
+				spec->upgrade = 0;
 				if (!strcmp(**argv, "tcp")) {
-					spec->ssl = 0;
-					spec->http = 0;
-					spec->upgrade = 0;
+					// use defaults
 				} else
 				if (!strcmp(**argv, "ssl")) {
 					spec->ssl = 1;
-					spec->http = 0;
-					spec->upgrade = 0;
 				} else
 				if (!strcmp(**argv, "http")) {
-					spec->ssl = 0;
 					spec->http = 1;
-					spec->upgrade = 0;
 				} else
 				if (!strcmp(**argv, "https")) {
 					spec->ssl = 1;
 					spec->http = 1;
-					spec->upgrade = 0;
 				} else
 				if (!strcmp(**argv, "autossl")) {
-					spec->ssl = 0;
-					spec->http = 0;
 					spec->upgrade = 1;
 				} else {
 					fprintf(stderr, "Unknown connection "
@@ -491,8 +383,6 @@ proxyspec_parse(int *argc, char **argv[], const char *natengine)
 		fprintf(stderr, "Incomplete proxyspec!\n");
 		exit(EXIT_FAILURE);
 	}
-
-	return spec;
 }
 
 /*
@@ -555,6 +445,853 @@ proxyspec_str(proxyspec_t *spec)
 	if (cbuf)
 		free(cbuf);
 	return s;
+}
+
+void
+opts_set_cacrt(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->cacrt)
+		X509_free(opts->cacrt);
+	opts->cacrt = ssl_x509_load(optarg);
+	if (!opts->cacrt) {
+		fprintf(stderr, "%s: error loading CA "
+						"cert from '%s':\n",
+						argv0, optarg);
+		if (errno) {
+			fprintf(stderr, "%s\n",
+					strerror(errno));
+		} else {
+			ERR_print_errors_fp(stderr);
+		}
+		exit(EXIT_FAILURE);
+	}
+	ssl_x509_refcount_inc(opts->cacrt);
+	sk_X509_insert(opts->chain, opts->cacrt, 0);
+	if (!opts->cakey) {
+		opts->cakey = ssl_key_load(optarg);
+	}
+#ifndef OPENSSL_NO_DH
+	if (!opts->dh) {
+		opts->dh = ssl_dh_load(optarg);
+	}
+#endif /* !OPENSSL_NO_DH */
+	fprintf(stderr, "CACrt: %s\n", optarg);
+}
+
+void
+opts_set_cakey(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->cakey)
+		EVP_PKEY_free(opts->cakey);
+	opts->cakey = ssl_key_load(optarg);
+	if (!opts->cakey) {
+		fprintf(stderr, "%s: error loading CA "
+						"key from '%s':\n",
+						argv0, optarg);
+		if (errno) {
+			fprintf(stderr, "%s\n",
+					strerror(errno));
+		} else {
+			ERR_print_errors_fp(stderr);
+		}
+		exit(EXIT_FAILURE);
+	}
+	if (!opts->cacrt) {
+		opts->cacrt = ssl_x509_load(optarg);
+		if (opts->cacrt) {
+			ssl_x509_refcount_inc(
+						   opts->cacrt);
+			sk_X509_insert(opts->chain,
+						   opts->cacrt, 0);
+		}
+	}
+#ifndef OPENSSL_NO_DH
+	if (!opts->dh) {
+		opts->dh = ssl_dh_load(optarg);
+	}
+#endif /* !OPENSSL_NO_DH */
+	fprintf(stderr, "CAKey: %s\n", optarg);
+}
+
+void
+opts_set_chain(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (ssl_x509chain_load(NULL, &opts->chain,
+						   optarg) == -1) {
+		fprintf(stderr, "%s: error loading "
+						"chain from '%s':\n",
+						argv0, optarg);
+		if (errno) {
+			fprintf(stderr, "%s\n",
+					strerror(errno));
+		} else {
+			ERR_print_errors_fp(stderr);
+		}
+		exit(EXIT_FAILURE);
+	}
+	fprintf(stderr, "CAChain: %s\n", optarg);
+}
+
+void
+opts_set_key(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->key)
+		EVP_PKEY_free(opts->key);
+	opts->key = ssl_key_load(optarg);
+	if (!opts->key) {
+		fprintf(stderr, "%s: error loading lea"
+						"f key from '%s':\n",
+						argv0, optarg);
+		if (errno) {
+			fprintf(stderr, "%s\n",
+					strerror(errno));
+		} else {
+			ERR_print_errors_fp(stderr);
+		}
+		exit(EXIT_FAILURE);
+	}
+#ifndef OPENSSL_NO_DH
+	if (!opts->dh) {
+		opts->dh = ssl_dh_load(optarg);
+	}
+#endif /* !OPENSSL_NO_DH */
+	fprintf(stderr, "LeafCerts: %s\n", optarg);
+}
+
+void
+opts_set_crl(opts_t *opts, const char *optarg)
+{
+	if (opts->crlurl)
+		free(opts->crlurl);
+	opts->crlurl = strdup(optarg);
+	fprintf(stderr, "CRL: %s\n", opts->crlurl);
+}
+
+void
+opts_set_tgcrtdir(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (!sys_isdir(optarg)) {
+		fprintf(stderr, "%s: '%s' is not a "
+						"directory\n",
+						argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	if (opts->tgcrtdir)
+		free(opts->tgcrtdir);
+	opts->tgcrtdir = strdup(optarg);
+	if (!opts->tgcrtdir)
+		oom_die(argv0);
+	fprintf(stderr, "TargetCertDir: %s\n", opts->tgcrtdir);
+}
+
+static void
+set_certgendir(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->certgendir)
+		free(opts->certgendir);
+	opts->certgendir = strdup(optarg);
+	if (!opts->certgendir)
+		oom_die(argv0);
+}
+
+void
+opts_set_certgendir_writegencerts(opts_t *opts, const char *argv0, const char *optarg)
+{
+	opts->certgen_writeall = 0;
+	set_certgendir(opts, argv0, optarg);
+	fprintf(stderr, "WriteGenCertsDir: certgendir=%s, writeall=%u\n", opts->certgendir, opts->certgen_writeall);
+}
+
+void
+opts_set_certgendir_writeall(opts_t *opts, const char *argv0, const char *optarg)
+{
+	opts->certgen_writeall = 1;
+	set_certgendir(opts, argv0, optarg);
+	fprintf(stderr, "WriteAllCertsDir: certgendir=%s, writeall=%u\n", opts->certgendir, opts->certgen_writeall);
+}
+
+void
+opts_set_deny_ocsp(opts_t *opts)
+{
+	opts->deny_ocsp = 1;
+}
+
+void
+opts_unset_deny_ocsp(opts_t *opts)
+{
+	opts->deny_ocsp = 0;
+}
+
+void
+opts_set_passthrough(opts_t *opts)
+{
+	opts->passthrough = 1;
+}
+
+void
+opts_unset_passthrough(opts_t *opts)
+{
+	opts->passthrough = 0;
+}
+
+#ifndef OPENSSL_NO_DH
+void
+opts_set_dh(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->dh)
+		DH_free(opts->dh);
+	opts->dh = ssl_dh_load(optarg);
+	if (!opts->dh) {
+		fprintf(stderr, "%s: error loading DH "
+						"params from '%s':\n",
+						argv0, optarg);
+		if (errno) {
+			fprintf(stderr, "%s\n",
+					strerror(errno));
+		} else {
+			ERR_print_errors_fp(stderr);
+		}
+		exit(EXIT_FAILURE);
+	}
+	fprintf(stderr, "DHGroupParams: %s\n", optarg);
+}
+#endif /* !OPENSSL_NO_DH */
+
+#ifndef OPENSSL_NO_ECDH
+void
+opts_set_ecdhcurve(opts_t *opts, const char *argv0, const char *optarg)
+{
+	EC_KEY *ec;
+	if (opts->ecdhcurve)
+		free(opts->ecdhcurve);
+	if (!(ec = ssl_ec_by_name(optarg))) {
+		fprintf(stderr, "%s: unknown curve "
+						"'%s'\n",
+						argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	EC_KEY_free(ec);
+	opts->ecdhcurve = strdup(optarg);
+	if (!opts->ecdhcurve)
+		oom_die(argv0);
+	fprintf(stderr, "ECDHCurve: %s\n", opts->ecdhcurve);
+}
+#endif /* !OPENSSL_NO_ECDH */
+
+void
+opts_set_sslcomp(opts_t *opts)
+{
+	opts->sslcomp = 1;
+}
+
+void
+opts_unset_sslcomp(opts_t *opts)
+{
+	opts->sslcomp = 0;
+}
+
+void
+opts_set_ciphers(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->ciphers)
+		free(opts->ciphers);
+	opts->ciphers = strdup(optarg);
+	if (!opts->ciphers)
+		oom_die(argv0);
+	fprintf(stderr, "Ciphers: %s\n", opts->ciphers);
+}
+
+/*
+ * Parse SSL proto string in optarg and look up the corresponding SSL method.
+ * Calls exit() on failure.
+ */
+void
+opts_proto_force(opts_t *opts, const char *optarg, const char *argv0)
+{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	if (opts->sslmethod != SSLv23_method) {
+#else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+	if (opts->sslversion) {
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+		fprintf(stderr, "%s: cannot use -r multiple times\n", argv0);
+		exit(EXIT_FAILURE);
+	}
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifdef HAVE_SSLV2
+	if (!strcmp(optarg, "ssl2")) {
+		opts->sslmethod = SSLv2_method;
+	} else
+#endif /* HAVE_SSLV2 */
+#ifdef HAVE_SSLV3
+	if (!strcmp(optarg, "ssl3")) {
+		opts->sslmethod = SSLv3_method;
+	} else
+#endif /* HAVE_SSLV3 */
+#ifdef HAVE_TLSV10
+	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
+		opts->sslmethod = TLSv1_method;
+	} else
+#endif /* HAVE_TLSV10 */
+#ifdef HAVE_TLSV11
+	if (!strcmp(optarg, "tls11")) {
+		opts->sslmethod = TLSv1_1_method;
+	} else
+#endif /* HAVE_TLSV11 */
+#ifdef HAVE_TLSV12
+	if (!strcmp(optarg, "tls12")) {
+		opts->sslmethod = TLSv1_2_method;
+	} else
+#endif /* HAVE_TLSV12 */
+#else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+/*
+ * Support for SSLv2 and the corresponding SSLv2_method(),
+ * SSLv2_server_method() and SSLv2_client_method() functions were
+ * removed in OpenSSL 1.1.0.
+ */
+#ifdef HAVE_SSLV3
+	if (!strcmp(optarg, "ssl3")) {
+		opts->sslversion = SSL3_VERSION;
+	} else
+#endif /* HAVE_SSLV3 */
+#ifdef HAVE_TLSV10
+	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
+		opts->sslversion = TLS1_VERSION;
+	} else
+#endif /* HAVE_TLSV10 */
+#ifdef HAVE_TLSV11
+	if (!strcmp(optarg, "tls11")) {
+		opts->sslversion = TLS1_1_VERSION;
+	} else
+#endif /* HAVE_TLSV11 */
+#ifdef HAVE_TLSV12
+	if (!strcmp(optarg, "tls12")) {
+		opts->sslversion = TLS1_2_VERSION;
+	} else
+#endif /* HAVE_TLSV12 */
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+	{
+		fprintf(stderr, "%s: Unsupported SSL/TLS protocol '%s'\n",
+		                argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	fprintf(stderr, "ForceSSLProto: %s\n", optarg);
+}
+
+/*
+ * Parse SSL proto string in optarg and set the corresponding no_foo bit.
+ * Calls exit() on failure.
+ */
+void
+opts_proto_disable(opts_t *opts, const char *optarg, const char *argv0)
+{
+#ifdef HAVE_SSLV2
+	if (!strcmp(optarg, "ssl2")) {
+		opts->no_ssl2 = 1;
+	} else
+#endif /* HAVE_SSLV2 */
+#ifdef HAVE_SSLV3
+	if (!strcmp(optarg, "ssl3")) {
+		opts->no_ssl3 = 1;
+	} else
+#endif /* HAVE_SSLV3 */
+#ifdef HAVE_TLSV10
+	if (!strcmp(optarg, "tls10") || !strcmp(optarg, "tls1")) {
+		opts->no_tls10 = 1;
+	} else
+#endif /* HAVE_TLSV10 */
+#ifdef HAVE_TLSV11
+	if (!strcmp(optarg, "tls11")) {
+		opts->no_tls11 = 1;
+	} else
+#endif /* HAVE_TLSV11 */
+#ifdef HAVE_TLSV12
+	if (!strcmp(optarg, "tls12")) {
+		opts->no_tls12 = 1;
+	} else
+#endif /* HAVE_TLSV12 */
+	{
+		fprintf(stderr, "%s: Unsupported SSL/TLS protocol '%s'\n",
+		                argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	fprintf(stderr, "DisableSSLProto: %s\n", optarg);
+}
+
+void
+opts_set_user(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (!sys_isuser(optarg)) {
+		fprintf(stderr, "%s: '%s' is not an "
+						"existing user\n",
+						argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	if (opts->dropuser)
+		free(opts->dropuser);
+	opts->dropuser = strdup(optarg);
+	if (!opts->dropuser)
+		oom_die(argv0);
+	fprintf(stderr, "User: %s\n", opts->dropuser);
+}
+
+void
+opts_set_group(opts_t *opts, const char *argv0, const char *optarg)
+{
+
+	if (!sys_isgroup(optarg)) {
+		fprintf(stderr, "%s: '%s' is not an "
+						"existing group\n",
+						argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	if (opts->dropgroup)
+		free(opts->dropgroup);
+	opts->dropgroup = strdup(optarg);
+	if (!opts->dropgroup)
+		oom_die(argv0);
+	fprintf(stderr, "Group: %s\n", opts->dropgroup);
+}
+
+void
+opts_set_jaildir(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (!sys_isdir(optarg)) {
+		fprintf(stderr, "%s: '%s' is not a "
+						"directory\n",
+						argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	if (opts->jaildir)
+		free(opts->jaildir);
+	opts->jaildir = realpath(optarg, NULL);
+	if (!opts->jaildir) {
+		fprintf(stderr, "%s: Failed to "
+						"canonicalize '%s': "
+						"%s (%i)\n",
+						argv0, optarg,
+						strerror(errno), errno);
+		exit(EXIT_FAILURE);
+	}
+	fprintf(stderr, "Chroot: %s\n", opts->jaildir);
+}
+
+void
+opts_set_pidfile(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->pidfile)
+		free(opts->pidfile);
+	opts->pidfile = strdup(optarg);
+	if (!opts->pidfile)
+		oom_die(argv0);
+	fprintf(stderr, "PidFile: %s\n", opts->pidfile);
+}
+
+void
+opts_set_connectlog(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->connectlog)
+		free(opts->connectlog);
+	opts->connectlog = strdup(optarg);
+	if (!opts->connectlog)
+		oom_die(argv0);
+	fprintf(stderr, "ConnectLog: %s\n", opts->connectlog);
+}
+
+void
+opts_set_contentlog(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->contentlog)
+		free(opts->contentlog);
+	opts->contentlog = strdup(optarg);
+	if (!opts->contentlog)
+		oom_die(argv0);
+	opts->contentlog_isdir = 0;
+	opts->contentlog_isspec = 0;
+	fprintf(stderr, "ContentLog: %s\n", opts->contentlog);
+}
+
+void
+opts_set_contentlogdir(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (!sys_isdir(optarg)) {
+		fprintf(stderr, "%s: '%s' is not a "
+						"directory\n",
+						argv0, optarg);
+		exit(EXIT_FAILURE);
+	}
+	if (opts->contentlog)
+		free(opts->contentlog);
+	opts->contentlog = realpath(optarg, NULL);
+	if (!opts->contentlog) {
+		fprintf(stderr, "%s: Failed to "
+						"canonicalize '%s': "
+						"%s (%i)\n",
+						argv0, optarg,
+						strerror(errno), errno);
+		exit(EXIT_FAILURE);
+	}
+	opts->contentlog_isdir = 1;
+	opts->contentlog_isspec = 0;
+	fprintf(stderr, "ContentLogDir: %s\n", opts->contentlog);
+}
+
+void
+opts_set_contentlogpathspec(opts_t *opts, const char *argv0, const char *optarg)
+{
+	char *lhs, *rhs, *p, *q;
+	size_t n;
+	if (opts->contentlog_basedir)
+		free(opts->contentlog_basedir);
+	if (opts->contentlog)
+		free(opts->contentlog);
+	if (log_content_split_pathspec(optarg, &lhs,
+								   &rhs) == -1) {
+		fprintf(stderr, "%s: Failed to split "
+						"'%s' in lhs/rhs: "
+						"%s (%i)\n",
+						argv0, optarg,
+						strerror(errno), errno);
+		exit(EXIT_FAILURE);
+	}
+	/* eliminate %% from lhs */
+	for (p = q = lhs; *p; p++, q++) {
+		if (q < p)
+			*q = *p;
+		if (*p == '%' && *(p+1) == '%')
+			p++;
+	}
+	*q = '\0';
+	/* all %% in lhs resolved to % */
+	if (sys_mkpath(lhs, 0777) == -1) {
+		fprintf(stderr, "%s: Failed to create "
+						"'%s': %s (%i)\n",
+						argv0, lhs,
+						strerror(errno), errno);
+		exit(EXIT_FAILURE);
+	}
+	opts->contentlog_basedir = realpath(lhs, NULL);
+	if (!opts->contentlog_basedir) {
+		fprintf(stderr, "%s: Failed to "
+						"canonicalize '%s': "
+						"%s (%i)\n",
+						argv0, lhs,
+						strerror(errno), errno);
+		exit(EXIT_FAILURE);
+	}
+	/* count '%' in opts->contentlog_basedir */
+	for (n = 0, p = opts->contentlog_basedir;
+		 *p;
+		 p++) {
+		if (*p == '%')
+			n++;
+	}
+	free(lhs);
+	n += strlen(opts->contentlog_basedir);
+	if (!(lhs = malloc(n + 1)))
+		oom_die(argv0);
+	/* re-encoding % to %%, copying basedir to lhs */
+	for (p = opts->contentlog_basedir, q = lhs;
+		 *p;
+		 p++, q++) {
+		*q = *p;
+		if (*q == '%')
+			*(++q) = '%';
+	}
+	*q = '\0';
+	/* lhs contains encoded realpathed basedir */
+	if (asprintf(&opts->contentlog,
+				 "%s/%s", lhs, rhs) < 0)
+		oom_die(argv0);
+	opts->contentlog_isdir = 0;
+	opts->contentlog_isspec = 1;
+	free(lhs);
+	free(rhs);
+	fprintf(stderr, "ContentLogPathSpec: basedir=%s, %s\n", opts->contentlog_basedir, opts->contentlog);
+}
+
+#ifdef HAVE_LOCAL_PROCINFO
+void
+opts_set_lprocinfo(opts_t *opts)
+{
+	opts->lprocinfo = 1;
+}
+
+void
+opts_unset_lprocinfo(opts_t *opts)
+{
+	opts->lprocinfo = 0;
+}
+#endif /* HAVE_LOCAL_PROCINFO */
+
+void
+opts_set_masterkeylog(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->masterkeylog)
+		free(opts->masterkeylog);
+	opts->masterkeylog = strdup(optarg);
+	if (!opts->masterkeylog)
+		oom_die(argv0);
+	fprintf(stderr, "MasterKeyLog: %s\n", opts->masterkeylog);
+}
+
+void
+opts_set_daemon(opts_t *opts)
+{
+	opts->detach = 1;
+}
+
+void
+opts_unset_daemon(opts_t *opts)
+{
+	opts->detach = 0;
+}
+
+void
+opts_set_debug(opts_t *opts)
+{
+	log_dbg_mode(LOG_DBG_MODE_ERRLOG);
+	opts->debug = 1;
+}
+
+void
+opts_unset_debug(opts_t *opts)
+{
+	log_dbg_mode(LOG_DBG_MODE_NONE);
+	opts->debug = 0;
+}
+
+static int
+check_value_yesno(char *value, char *name, int line_num)
+{
+	// Compare strlen(s2)+1 chars to match exactly
+	if (!strncmp(value, "yes", 4)) {
+		return 1;
+	} else if (!strncmp(value, "no", 3)) {
+		return 0;
+	}
+	fprintf(stderr, "Invalid %s %s at line %d, use yes|no\n", name, value, line_num);
+	return -1;
+}
+
+int
+load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
+{
+	FILE *f;
+	int rv, line_num, yes;
+	size_t line_len;
+	char *n, *value, *v, *value_end;
+	char *line, *name;
+	char natengine[NATENGINE_SIZE];
+	
+	strncpy(natengine, prev_natengine, NATENGINE_SIZE);
+
+	f = fopen(opts->conffile, "r");
+	if (!f) {
+		fprintf(stderr, "Error opening conf file %s: %s\n", opts->conffile, strerror(errno));
+		return -1;
+	}
+
+	line = NULL;
+	line_num = 0;
+	while (!feof(f)) {
+		rv = getline(&line, &line_len, f);
+		if (rv == -1) {
+			break;
+		}
+		if (line == NULL) {
+			fprintf(stderr, "getline() buf=NULL");
+			return -1;
+		}
+		line_num++;
+
+		// skip white space
+		for (name = line; *name == ' ' || *name == '\t'; name++); 
+
+		// skip comments and empty lines
+		if ((name[0] == '\0') || (name[0] == '#') || (name[0] == ';') ||
+			(name[0] == '\r') || (name[0] == '\n')) {
+			continue;
+		}
+
+		// skip to the end of option name and terminate it with '\0'
+		for (n = name;; n++) {
+			if (*n == ' ' || *n == '\t') {
+				*n = '\0';
+				n++;
+				break;
+			}
+			if (*n == '\0') {
+				n = NULL;
+				break;
+			}
+		}
+
+		// no value
+		if (n == NULL) {
+			fprintf(stderr, "Conf error at line %d\n", line_num);
+			fclose(f);
+			if (line) {
+				free(line);
+			}
+			return -1;
+		}
+		
+		// skip white space before value
+		while (*n == ' ' || *n == '\t') {
+			n++;
+		}
+
+		value = n;
+
+		// find end of value and terminate it with '\0'
+		// find first occurrence of trailing white space
+		value_end = NULL;
+		for (v = value;; v++) {
+			if (*v == '\0') {
+				break;
+			}
+			if (*v == '\r' || *v == '\n') {
+				*v = '\0';
+				break;
+			}
+			if (*v == ' ' || *v == '\t') {
+				if (!value_end) {
+					value_end = v;
+				}
+			} else {
+				value_end = NULL;
+			}
+		}
+
+		if (value_end) {
+			*value_end = '\0';
+		}
+
+		// Compare strlen(s2)+1 chars to match exactly
+		if (!strncmp(name, "CACert", 7)) {
+			opts_set_cacrt(opts, argv0, value);
+		} else if (!strncmp(name, "CAKey", 6)) {
+			opts_set_cakey(opts, argv0, value);
+		} else if (!strncmp(name, "CAChain", 8)) {
+			opts_set_chain(opts, argv0, value);
+		} else if (!strncmp(name, "LeafCerts", 10)) {
+			opts_set_key(opts, argv0, value);
+		} else if (!strncmp(name, "CRL", 4)) {
+			opts_set_crl(opts, value);
+		} else if (!strncmp(name, "TargetCertDir", 14)) {
+			opts_set_tgcrtdir(opts, argv0, value);
+		} else if (!strncmp(name, "WriteGenCertsDir", 17)) {
+			opts_set_certgendir_writegencerts(opts, argv0, value);
+		} else if (!strncmp(name, "WriteAllCertsDir", 17)) {
+			opts_set_certgendir_writeall(opts, argv0, value);
+		} else if (!strncmp(name, "DenyOCSP", 9)) {
+			yes = check_value_yesno(value, "DenyOCSP", line_num);
+			if (yes >= 0) {
+				yes ? opts_set_deny_ocsp(opts) : opts_unset_deny_ocsp(opts);
+			}
+			fprintf(stderr, "DenyOCSP: %u\n", opts->deny_ocsp);
+		} else if (!strncmp(name, "Passthrough", 12)) {
+			yes = check_value_yesno(value, "Passthrough", line_num);
+			if (yes >= 0) {
+				yes ? opts_set_passthrough(opts) : opts_unset_passthrough(opts);
+			}
+			fprintf(stderr, "Passthrough: %u\n", opts->passthrough);
+#ifndef OPENSSL_NO_DH
+		} else if (!strncmp(name, "DHGroupParams", 14)) {
+			opts_set_dh(opts, argv0, value);
+#endif /* !OPENSSL_NO_DH */
+#ifndef OPENSSL_NO_ECDH
+		} else if (!strncmp(name, "ECDHCurve", 10)) {
+			opts_set_ecdhcurve(opts, argv0, value);
+#endif /* !OPENSSL_NO_ECDH */
+#ifdef SSL_OP_NO_COMPRESSION
+		} else if (!strncmp(name, "SSLCompression", 15)) {
+			yes = check_value_yesno(value, "SSLCompression", line_num);
+			if (yes >= 0) {
+				yes ? opts_set_sslcomp(opts) : opts_unset_sslcomp(opts);
+			}
+			fprintf(stderr, "SSLCompression: %u\n", opts->sslcomp);
+#endif /* SSL_OP_NO_COMPRESSION */
+		} else if (!strncmp(name, "ForceSSLProto", 14)) {
+			opts_proto_force(opts, value, argv0);
+		} else if (!strncmp(name, "DisableSSLProto", 16)) {
+			opts_proto_disable(opts, value, argv0);
+		} else if (!strncmp(name, "Ciphers", 8)) {
+			opts_set_ciphers(opts, argv0, value);
+		} else if (!strncmp(name, "NATEngine", 10)) {
+			strncpy(natengine, value, NATENGINE_SIZE);
+			fprintf(stderr, "NATEngine: %s\n", natengine);
+		} else if (!strncmp(name, "User", 5)) {
+			opts_set_user(opts, argv0, value);
+		} else if (!strncmp(name, "Group", 6)) {
+			opts_set_group(opts, argv0, value);
+		} else if (!strncmp(name, "Chroot", 7)) {
+			opts_set_jaildir(opts, argv0, value);
+		} else if (!strncmp(name, "PidFile", 8)) {
+			opts_set_pidfile(opts, argv0, value);
+		} else if (!strncmp(name, "ConnectLog", 11)) {
+			opts_set_connectlog(opts, argv0, value);
+		} else if (!strncmp(name, "ContentLog", 11)) {
+			opts_set_contentlog(opts, argv0, value);
+		} else if (!strncmp(name, "ContentLogDir", 14)) {
+			opts_set_contentlogdir(opts, argv0, value);
+		} else if (!strncmp(name, "ContentLogPathSpec", 19)) {
+			opts_set_contentlogpathspec(opts, argv0, value);
+#ifdef HAVE_LOCAL_PROCINFO
+		} else if (!strncmp(name, "LogProcInfo", 11)) {
+			yes = check_value_yesno(value, "LogProcInfo", line_num);
+			if (yes >= 0) {
+				yes ? opts_set_lprocinfo(opts) : opts_unset_lprocinfo(opts);
+			}
+			fprintf(stderr, "LogProcInfo: %u\n", opts->lprocinfo);
+#endif /* HAVE_LOCAL_PROCINFO */
+		} else if (!strncmp(name, "MasterKeyLog", 13)) {
+			opts_set_masterkeylog(opts, argv0, value);
+		} else if (!strncmp(name, "Daemon", 7)) {
+			yes = check_value_yesno(value, "Daemon", line_num);
+			if (yes >= 0) {
+				yes ? opts_set_daemon(opts) : opts_unset_daemon(opts);
+			}
+			fprintf(stderr, "Daemon: %u\n", opts->detach);
+		} else if (!strncmp(name, "Debug", 6)) {
+			yes = check_value_yesno(value, "Debug", line_num);
+			if (yes >= 0) {
+				yes ? opts_set_debug(opts) : opts_unset_debug(opts);
+			}
+			fprintf(stderr, "Debug: %u\n", opts->debug);
+		} else if (!strncmp(name, "ProxySpec", 10)) {
+			char **argv = malloc(strlen(value) + 1);
+			char **save_argv = argv;
+			int argc = 0;
+			char *p, *last = NULL;
+
+			for ((p = strtok_r(value, " ", &last)); p; (p = strtok_r(NULL, " ", &last))) {
+				// Limit max # token
+				if (argc < 10) {
+					argv[argc++] = p;
+				}
+			}
+			
+			proxyspec_parse(&argc, &argv, natengine, opts);
+			free(save_argv);
+		} else {
+			fprintf(stderr, "Unknown option '%s' at %s line %d\n", name, opts->conffile, line_num);
+			fclose(f);
+			if (line) {
+				free(line);
+			}
+			return -1;
+		}
+
+		continue;
+	}
+
+	fclose(f);
+	if (line) {
+		free(line);
+	}
+	return 0;
 }
 
 /* vim: set noet ft=c: */

--- a/opts.c
+++ b/opts.c
@@ -229,7 +229,6 @@ opts_proto_dbg_dump(opts_t *opts)
 	               "");
 }
 
-
 /*
  * Parse proxyspecs using a simple state machine.
  */
@@ -1074,6 +1073,8 @@ check_value_yesno(char *value, char *name, int line_num)
 	return -1;
 }
 
+#define MAX_TOKEN 10
+
 int
 load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 {
@@ -1264,14 +1265,15 @@ load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 			yes ? opts_set_debug(opts) : opts_unset_debug(opts);
 			fprintf(stderr, "Debug: %u\n", opts->debug);
 		} else if (!strncmp(name, "ProxySpec", 10)) {
-			char **argv = malloc(strlen(value) + 1);
+			// Use MAX_TOKEN instead of computing the actual number of tokens in value
+			char **argv = malloc(sizeof(char *) * MAX_TOKEN);
 			char **save_argv = argv;
 			int argc = 0;
 			char *p, *last = NULL;
 
 			for ((p = strtok_r(value, " ", &last)); p; (p = strtok_r(NULL, " ", &last))) {
 				// Limit max # token
-				if (argc < 10) {
+				if (argc < MAX_TOKEN) {
 					argv[argc++] = p;
 				}
 			}

--- a/opts.h
+++ b/opts.h
@@ -90,6 +90,7 @@ typedef struct opts {
 	char *dropgroup;
 	char *jaildir;
 	char *pidfile;
+	char *conffile;
 	char *connectlog;
 	char *contentlog;
 	char *contentlog_basedir; /* static part of logspec, for privsep srv */
@@ -112,19 +113,55 @@ typedef struct opts {
 	char *crlurl;
 } opts_t;
 
+void NORET oom_die(const char *) NONNULL(1);
+
 opts_t *opts_new(void) MALLOC;
 void opts_free(opts_t *) NONNULL(1);
 int opts_has_ssl_spec(opts_t *) NONNULL(1) WUNRES;
 int opts_has_dns_spec(opts_t *) NONNULL(1) WUNRES;
-void opts_proto_force(opts_t *, const char *, const char *) NONNULL(1,2,3);
-void opts_proto_disable(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_proto_dbg_dump(opts_t *) NONNULL(1);
 #define OPTS_DEBUG(opts) unlikely((opts)->debug)
 
-proxyspec_t * proxyspec_parse(int *, char **[], const char *) MALLOC;
+void proxyspec_parse(int *, char **[], const char *, opts_t *);
 void proxyspec_free(proxyspec_t *) NONNULL(1);
 char * proxyspec_str(proxyspec_t *) NONNULL(1) MALLOC;
 
+void opts_set_cacrt(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_cakey(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_chain(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_key(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_crl(opts_t *, const char *) NONNULL(1,2);
+void opts_set_tgcrtdir(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_certgendir_writeall(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_certgendir_writegencerts(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_deny_ocsp(opts_t *) NONNULL(1);
+void opts_set_passthrough(opts_t *) NONNULL(1);
+#ifndef OPENSSL_NO_DH
+void opts_set_dh(opts_t *, const char *, const char *) NONNULL(1,2,3);
+#endif /* !OPENSSL_NO_DH */
+#ifndef OPENSSL_NO_ECDH
+void opts_set_ecdhcurve(opts_t *, const char *, const char *) NONNULL(1,2,3);
+#endif /* !OPENSSL_NO_ECDH */
+void opts_unset_sslcomp(opts_t *) NONNULL(1);
+void opts_proto_force(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_proto_disable(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_ciphers(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_user(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_group(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_jaildir(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_pidfile(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_connectlog(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_contentlog(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_contentlogdir(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_contentlogpathspec(opts_t *, const char *, const char *) NONNULL(1,2,3);
+#ifdef HAVE_LOCAL_PROCINFO
+void opts_set_lprocinfo(opts_t *) NONNULL(1);
+#endif /* HAVE_LOCAL_PROCINFO */
+void opts_set_masterkeylog(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_daemon(opts_t *) NONNULL(1);
+void opts_set_debug(opts_t *) NONNULL(1);
+
+int load_conffile(opts_t *, const char *, const char *) NONNULL(1,2,3);
 #endif /* !OPTS_H */
 
 /* vim: set noet ft=c: */

--- a/opts.h
+++ b/opts.h
@@ -124,7 +124,7 @@ void opts_proto_dbg_dump(opts_t *) NONNULL(1);
 
 void proxyspec_parse(int *, char **[], const char *, opts_t *);
 void proxyspec_free(proxyspec_t *) NONNULL(1);
-char * proxyspec_str(proxyspec_t *) NONNULL(1) MALLOC;
+char *proxyspec_str(proxyspec_t *) NONNULL(1) MALLOC;
 
 void opts_set_cacrt(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_cakey(opts_t *, const char *, const char *) NONNULL(1,2,3);
@@ -143,8 +143,8 @@ void opts_set_dh(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_ecdhcurve(opts_t *, const char *, const char *) NONNULL(1,2,3);
 #endif /* !OPENSSL_NO_ECDH */
 void opts_unset_sslcomp(opts_t *) NONNULL(1);
-void opts_proto_force(opts_t *, const char *, const char *) NONNULL(1,2,3);
-void opts_proto_disable(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_force_proto(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_disable_proto(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_ciphers(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_user(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_group(opts_t *, const char *, const char *) NONNULL(1,2,3);

--- a/opts.h
+++ b/opts.h
@@ -122,7 +122,7 @@ int opts_has_dns_spec(opts_t *) NONNULL(1) WUNRES;
 void opts_proto_dbg_dump(opts_t *) NONNULL(1);
 #define OPTS_DEBUG(opts) unlikely((opts)->debug)
 
-void proxyspec_parse(int *, char **[], const char *, opts_t *);
+void proxyspec_parse(int *, char **[], const char *, proxyspec_t **);
 void proxyspec_free(proxyspec_t *) NONNULL(1);
 char *proxyspec_str(proxyspec_t *) NONNULL(1) MALLOC;
 

--- a/opts.t.c
+++ b/opts.t.c
@@ -86,13 +86,11 @@ static char *argv14[] = {
 
 START_TEST(proxyspec_parse_01)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv01;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -106,19 +104,17 @@ START_TEST(proxyspec_parse_01)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_02)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv02;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -132,43 +128,43 @@ START_TEST(proxyspec_parse_02)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_03)
 {
+	proxyspec_t *spec = NULL;
 	int argc = 2;
 	char **argv = argv01;
-	opts_t *opts = opts_new();
 
 	close(2);
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	opts_free(opts);
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
+	if (spec)
+		proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_04)
 {
+	proxyspec_t *spec = NULL;
 	int argc = 4;
 	char **argv = argv01;
-	opts_t *opts = opts_new();
 
 	close(2);
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	opts_free(opts);
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
+	if (spec)
+		proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_05)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv03;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -182,19 +178,17 @@ START_TEST(proxyspec_parse_05)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_06)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv04;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -208,19 +202,17 @@ START_TEST(proxyspec_parse_06)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_07)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv05;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -234,19 +226,17 @@ START_TEST(proxyspec_parse_07)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_08)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv06;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -259,43 +249,43 @@ START_TEST(proxyspec_parse_08)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_09)
 {
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv07;
-	opts_t *opts = opts_new();
 
 	close(2);
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	opts_free(opts);
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
+	if (spec)
+		proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_10)
 {
+	proxyspec_t *spec = NULL;
 	int argc = 4;
 	char **argv = argv06;
-	opts_t *opts = opts_new();
 
 	close(2);
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	opts_free(opts);
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
+	if (spec)
+		proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_11)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 3;
 	char **argv = argv08;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -309,31 +299,30 @@ START_TEST(proxyspec_parse_11)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_12)
 {
+	proxyspec_t *spec = NULL;
 	int argc = 4;
 	char **argv = argv08;
-	opts_t *opts = opts_new();
 
 	close(2);
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	opts_free(opts);
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
+	if (spec)
+		proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_13)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 10;
 	char **argv = argv09;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -358,19 +347,17 @@ START_TEST(proxyspec_parse_13)
 	fail_unless(!spec->next->natengine, "natengine is set");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_14)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 6;
 	char **argv = argv10;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -396,19 +383,17 @@ START_TEST(proxyspec_parse_14)
 	            "natengine mismatch");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_15)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 3;
 	char **argv = argv11;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -421,19 +406,17 @@ START_TEST(proxyspec_parse_15)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_16)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 10;
 	char **argv = argv12;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -458,31 +441,30 @@ START_TEST(proxyspec_parse_16)
 	fail_unless(!spec->next->natengine, "natengine is set");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_17)
 {
+	proxyspec_t *spec = NULL;
 	int argc = 5;
 	char **argv = argv13;
-	opts_t *opts = opts_new();
 
 	close(2);
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	opts_free(opts);
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
+	if (spec)
+		proxyspec_free(spec);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_18)
 {
-	proxyspec_t *spec;
+	proxyspec_t *spec = NULL;
 	int argc = 8;
 	char **argv = argv14;
-	opts_t *opts = opts_new();
 
-	proxyspec_parse(&argc, &argv, NATENGINE, opts);
-	spec = opts->spec;
+	proxyspec_parse(&argc, &argv, NATENGINE, &spec);
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -506,7 +488,7 @@ START_TEST(proxyspec_parse_18)
 	fail_unless(!!spec->next->natengine, "natengine is not set");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	opts_free(opts);
+	proxyspec_free(spec);
 }
 END_TEST
 

--- a/opts.t.c
+++ b/opts.t.c
@@ -89,8 +89,10 @@ START_TEST(proxyspec_parse_01)
 	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv01;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -104,7 +106,7 @@ START_TEST(proxyspec_parse_01)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
@@ -113,8 +115,10 @@ START_TEST(proxyspec_parse_02)
 	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv02;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -128,33 +132,31 @@ START_TEST(proxyspec_parse_02)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_03)
 {
-	proxyspec_t *spec;
 	int argc = 2;
 	char **argv = argv01;
+	opts_t *opts = opts_new();
 
 	close(2);
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
-	if (spec)
-		proxyspec_free(spec);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	opts_free(opts);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_04)
 {
-	proxyspec_t *spec;
 	int argc = 4;
 	char **argv = argv01;
+	opts_t *opts = opts_new();
 
 	close(2);
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
-	if (spec)
-		proxyspec_free(spec);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	opts_free(opts);
 }
 END_TEST
 
@@ -163,8 +165,10 @@ START_TEST(proxyspec_parse_05)
 	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv03;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -178,7 +182,7 @@ START_TEST(proxyspec_parse_05)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
@@ -187,8 +191,10 @@ START_TEST(proxyspec_parse_06)
 	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv04;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -202,7 +208,7 @@ START_TEST(proxyspec_parse_06)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
@@ -211,8 +217,10 @@ START_TEST(proxyspec_parse_07)
 	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv05;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -226,7 +234,7 @@ START_TEST(proxyspec_parse_07)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
@@ -235,8 +243,10 @@ START_TEST(proxyspec_parse_08)
 	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv06;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -249,33 +259,31 @@ START_TEST(proxyspec_parse_08)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_09)
 {
-	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv07;
+	opts_t *opts = opts_new();
 
 	close(2);
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
-	if (spec)
-		proxyspec_free(spec);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	opts_free(opts);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_10)
 {
-	proxyspec_t *spec;
 	int argc = 4;
 	char **argv = argv06;
+	opts_t *opts = opts_new();
 
 	close(2);
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
-	if (spec)
-		proxyspec_free(spec);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	opts_free(opts);
 }
 END_TEST
 
@@ -284,8 +292,10 @@ START_TEST(proxyspec_parse_11)
 	proxyspec_t *spec;
 	int argc = 3;
 	char **argv = argv08;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -299,20 +309,19 @@ START_TEST(proxyspec_parse_11)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_12)
 {
-	proxyspec_t *spec;
 	int argc = 4;
 	char **argv = argv08;
+	opts_t *opts = opts_new();
 
 	close(2);
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
-	if (spec)
-		proxyspec_free(spec);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	opts_free(opts);
 }
 END_TEST
 
@@ -321,8 +330,10 @@ START_TEST(proxyspec_parse_13)
 	proxyspec_t *spec;
 	int argc = 10;
 	char **argv = argv09;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -347,7 +358,7 @@ START_TEST(proxyspec_parse_13)
 	fail_unless(!spec->next->natengine, "natengine is set");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
@@ -356,8 +367,10 @@ START_TEST(proxyspec_parse_14)
 	proxyspec_t *spec;
 	int argc = 6;
 	char **argv = argv10;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -383,7 +396,7 @@ START_TEST(proxyspec_parse_14)
 	            "natengine mismatch");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
@@ -392,8 +405,10 @@ START_TEST(proxyspec_parse_15)
 	proxyspec_t *spec;
 	int argc = 3;
 	char **argv = argv11;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -406,7 +421,7 @@ START_TEST(proxyspec_parse_15)
 	fail_unless(!spec->natlookup, "natlookup() is set");
 	fail_unless(!spec->natsocket, "natsocket() is set");
 	fail_unless(!spec->next, "next is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
@@ -415,8 +430,10 @@ START_TEST(proxyspec_parse_16)
 	proxyspec_t *spec;
 	int argc = 10;
 	char **argv = argv12;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(spec->ssl, "not SSL");
 	fail_unless(spec->http, "not HTTP");
@@ -441,20 +458,19 @@ START_TEST(proxyspec_parse_16)
 	fail_unless(!spec->next->natengine, "natengine is set");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 
 START_TEST(proxyspec_parse_17)
 {
-	proxyspec_t *spec;
 	int argc = 5;
 	char **argv = argv13;
+	opts_t *opts = opts_new();
 
 	close(2);
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
-	if (spec)
-		proxyspec_free(spec);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	opts_free(opts);
 }
 END_TEST
 
@@ -463,8 +479,10 @@ START_TEST(proxyspec_parse_18)
 	proxyspec_t *spec;
 	int argc = 8;
 	char **argv = argv14;
+	opts_t *opts = opts_new();
 
-	spec = proxyspec_parse(&argc, &argv, NATENGINE);
+	proxyspec_parse(&argc, &argv, NATENGINE, opts);
+	spec = opts->spec;
 	fail_unless(!!spec, "failed to parse spec");
 	fail_unless(!spec->ssl, "SSL");
 	fail_unless(!spec->http, "HTTP");
@@ -488,7 +506,7 @@ START_TEST(proxyspec_parse_18)
 	fail_unless(!!spec->next->natengine, "natengine is not set");
 	fail_unless(!spec->next->natlookup, "natlookup() is set");
 	fail_unless(!spec->next->natsocket, "natsocket() is set");
-	proxyspec_free(spec);
+	opts_free(opts);
 }
 END_TEST
 

--- a/privsep.c
+++ b/privsep.c
@@ -312,6 +312,7 @@ privsep_server_handle_req(opts_t *opts, int srvsock)
 	}
 	case PRIVSEP_REQ_OPENFILE_P:
 		mkpath = 1;
+		/* fall through */
 	case PRIVSEP_REQ_OPENFILE: {
 		char *fn;
 		int fd;

--- a/sslsplit.1
+++ b/sslsplit.1
@@ -41,6 +41,8 @@ sslsplit \-\- transparent SSL/TLS interception
 [\fB-OPZwWdDgGsrReumjplLSFiM\fP] \fB-t\fP \fIdir\fP
 \fIproxyspecs\fP [...]
 .br
+.B sslsplit [\fB-kCKwWOPZdDgGsrReumjplLSFiM\fP] -f \fIconffile\fP
+.br
 .B sslsplit -E
 .br
 .B sslsplit -V
@@ -137,6 +139,9 @@ returned by \fB-E\fP.
 .B \-E
 List all supported NAT engines available on the system and exit.  See
 NAT ENGINES for a list of NAT engines currently supported by SSLsplit.
+.TP
+.B \-f \fIconffile\fP
+Read configuraion from \fIconffile\fP.
 .TP
 .B \-F \fIlogspec\fP
 Log connection content to separate log files with the given path specification
@@ -723,7 +728,7 @@ SSLsplit uses SSL session caching on both ends to minimize the amount of full
 SSL handshakes, but even then, the limiting factor in handling SSL connections
 are the actual bignum computations.
 .SH "SEE ALSO"
-openssl(1), ciphers(1), speed(1),
+sslsplit.conf(5), openssl(1), ciphers(1), speed(1),
 pf(4), ipfw(8), iptables(8), ip6tables(8), ip(8),
 hostapd(8), arpspoof(8), parasite6(8), yersinia(8),
 .I https://www.roe.ch/SSLsplit

--- a/sslsplit.conf
+++ b/sslsplit.conf
@@ -1,0 +1,93 @@
+# This is the SSLsplit configuration file
+
+# Use CA cert (and key) to sign forged certs
+CACert /etc/sslsplit/ca.crt
+
+# Use CA key (and cert) to sign forged certs
+CAKey /etc/sslsplit/ca.key
+
+# Use CA chain from pemfile (intermediate and root CA certs)
+#CAChain /etc/sslsplit/chain.crt
+
+# Use key from pemfile for leaf certs (default: generate)
+#LeafCerts /etc/sslsplit/leaf.key
+
+# Use URL as CRL distribution point for all forged certs
+#CRL http://example.com
+
+# Use cert+chain+key PEM files from certdir to target all sites
+# matching the common names (non-matching: generate if CA)
+#TargetCertDir /etc/sslsplit/target
+
+# Write leaf key and only generated certificates to gendir
+#WriteGenCertsDir /var/run/sslsplit
+
+# Write leaf key and all certificates to gendir
+#WriteAllCertsDir /var/run/sslsplit
+
+# Deny all OCSP requests on all proxyspecs
+#DenyOCSP yes
+
+# Passthrough SSL connections if they cannot be split because of
+# client cert auth or no matching cert and no CA (default: drop)
+#Passthrough yes
+
+# Use DH group params from pemfile (default: keyfiles or auto)
+#DHGroupParams /etc/sslsplit/dh.pem
+
+# Use ECDH named curve (default: prime256v1)
+#ECDHCurve prime256v1
+
+# Enable/disable SSL/TLS compression on all connections
+#SSLCompression no
+
+# Force SSL/TLS protocol version only (default: all)
+#ForceSSLProto tls12
+
+# Disable SSL/TLS protocol version (default: none)
+#DisableSSLProto tls10
+
+# Use the given OpenSSL cipher suite spec (default: ALL:-aNULL)
+Ciphers MEDIUM:HIGH
+
+# Specify default NAT engine to use
+#NATEngine netfilter
+
+# Drop privileges to user and group (default if run as root: nobody)
+#User sslsplit
+#Group sslsplit
+
+# chroot() to jaildir (impacts sni proxyspecs, see manual page)
+#Chroot /var/run/sslsplit
+
+# Write pid to pidfile (default: no pid file)
+#PidFile /var/run/sslsplit.pid
+
+# Connect log: log one line summary per connection to logfile
+#ConnectLog /var/log/sslsplit/connect.log
+
+# Content log: full data to file or named pipe (excludes -S/-F)
+#ContentLog /var/log/sslsplit/content.log
+
+# Content log: full data to separate files in dir (excludes -L/-F)
+#ContentLogDir /var/log/sslsplit/content
+
+# Content log: full data to sep files with %% subst (excl. -L/-S)
+#ContentLogPathSpec /var/log/sslsplit/%%X/%%u-%%s-%%d-%%T.log
+
+# Look up local process owning each connection for logging
+#LogProcInfo yes
+
+# Log master keys to logfile in SSLKEYLOGFILE format
+#MasterKeyLog /var/log/sslsplit/masterkeys.log
+
+# Daemon mode: run in background, log error messages to syslog
+Daemon yes
+
+# Debug mode: run in foreground, log debug messages on stderr
+#Debug yes
+
+# Proxy specifications
+# type listenaddr+port
+ProxySpec https 127.0.0.1 8443
+ProxySpec https ::1 8443

--- a/sslsplit.conf
+++ b/sslsplit.conf
@@ -88,6 +88,6 @@ Daemon yes
 #Debug yes
 
 # Proxy specifications
-# type listenaddr+port
+# type listenaddr+port [natengine|targetaddr+port|"sni"+port]
 ProxySpec https 127.0.0.1 8443
 ProxySpec https ::1 8443

--- a/sslsplit.conf.5
+++ b/sslsplit.conf.5
@@ -1,0 +1,160 @@
+.\" SSLsplit - transparent SSL/TLS interception
+.\" Copyright (c) 2009-2018, Daniel Roethlisberger <daniel@roe.ch>.
+.\" All rights reserved.
+.\" https://www.roe.ch/SSLsplit
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions, and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in the
+.\"    documentation and/or other materials provided with the distribution.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+.\" IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+.\" OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+.\" IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+.\" NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+.\" DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+.\" THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+.\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+.\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+.\"
+.TH "sslsplit.conf" "5" "May 7, 2018" "sslsplit 0.5.3" "SSLsplit"
+.SH "NAME"
+.LP 
+\fBsslsplit.conf\fR \- Configuration file for SSLsplit
+.SH "DESCRIPTION"
+.LP 
+The file sslsplit.conf configures SSLsplit, sslsplit(1).
+.SH "FILE FORMAT"
+The file consists of comments and options with arguments. Each line which starts with a hash (\fB#\fR) symbol is ignored by the parser. Options and arguments are of the form \fBOption Argument\fR. The arguments are of the following types:
+.TP
+\fBBOOL\fR 
+Boolean value (yes/no).
+.TP 
+\fBSTRING\fR
+String.
+.SH "DIRECTIVES"
+.LP 
+When an option is not used (hashed or doesn't exist in the configuration file) sslsplit takes a default action.
+.TP 
+\fBCACert STRING\fR
+Use CA cert (and key) to sign forged certs.
+.TP
+\fBCAKey STRING\fR
+Use CA key (and cert) to sign forged certs.
+.TP
+\fBCAChain STRING\fR
+Use CA chain from pemfile (intermediate and root CA certs).
+.TP
+\fBLeafCerts STRING\fR
+Use key from pemfile for leaf certs.
+.br
+Default: generate
+.TP
+\fBCRL STRING\fR
+Use URL as CRL distribution point for all forged certs.
+.TP
+\fBTargetCertDir STRING\fR
+Use cert+chain+key PEM files from certdir to target all sites matching the common names (non-matching: generate if CA).
+.TP
+\fBWriteGenCertsDir STRING\fR
+Write leaf key and only generated certificates to gendir.
+.TP
+\fBWriteAllCertsDir STRING\fR
+Write leaf key and all certificates to gendir.
+.TP
+\fBDenyOCSP BOOL\fR
+Deny all OCSP requests on all proxyspecs.
+.TP
+\fBPassthrough BOOL\fR
+Passthrough SSL connections if they cannot be split because of client cert auth or no matching cert and no CA.
+.br 
+Default: drop
+.TP
+\fBDHGroupParams STRING\fR
+Use DH group params from pemfile.
+.br 
+Default: keyfiles or auto
+.TP
+\fBECDHCurve STRING\fR
+Use ECDH named curve.
+.br 
+Default: prime256v1
+.TP
+\fBSSLCompression BOOL\fR
+Enable/disable SSL/TLS compression on all connections.
+.TP
+\fBForceSSLProto STRING\fR
+Force SSL/TLS protocol version only.
+.br 
+Default: all
+.TP
+\fBDisableSSLProto STRING\fR
+Disable SSL/TLS protocol version.
+.br 
+Default: none
+.TP
+\fBCiphers STRING\fR
+Use the given OpenSSL cipher suite spec.
+.br 
+Default: ALL:-aNULL
+.TP 
+\fBNATEngine STRING\fR
+Specify default NAT engine to use.
+.TP 
+\fBUser STRING\fR
+Drop privileges to user.
+.br 
+Default: nobody, if run as root
+.TP
+\fBGroup STRING\fR
+Drop privileges to group.
+.br
+Default: Primary group of user
+.TP 
+\fBChroot STRING\fR
+chroot() to jaildir (impacts sni proxyspecs, see sslsplit(1)).
+.TP 
+\fBPidFile STRING\fR
+Write pid to file.
+.TP 
+\fBConnectLog STRING\fR
+Connect log: log one line summary per connection to logfile.
+.TP 
+\fBContentLog STRING\fR
+Content log: full data to file or named pipe (excludes ContentLogDir/ContentLogPathSpec).
+.TP 
+\fBContentLogDir STRING\fR
+Content log: full data to separate files in dir (excludes ContentLog/ContentLogPathSpec).
+.TP 
+\fBContentLogPathSpec STRING\fR
+Content log: full data to sep files with %% subst (excludes ContentLog/ContentLogDir).
+.TP 
+\fBLogProcInfo BOOL\fR
+Look up local process owning each connection for logging.
+.TP 
+\fBMasterKeyLog STRING\fR
+Log master keys to logfile in SSLKEYLOGFILE format.
+.TP 
+\fBDaemon BOOL\fR
+Daemon mode: run in background, log error messages to syslog.
+.TP 
+\fBDebug BOOL\fR
+Debug mode: run in foreground, log debug messages on stderr.
+.TP 
+\fBProxySpec STRING\fR
+Proxy specification: type listenaddr+port. Multiple specs are allowed, one on each line.
+.SH "FILES"
+.LP 
+/etc/sslsplit/sslsplit.conf
+.SH "AUTHOR"
+.LP 
+Daniel Roethlisberger <daniel@roe.ch>
+.SH "SEE ALSO"
+.LP 
+sslsplit(1)

--- a/sslsplit.conf.5
+++ b/sslsplit.conf.5
@@ -148,7 +148,7 @@ Daemon mode: run in background, log error messages to syslog.
 Debug mode: run in foreground, log debug messages on stderr.
 .TP 
 \fBProxySpec STRING\fR
-Proxy specification: type listenaddr+port. Multiple specs are allowed, one on each line.
+Proxy specification: type listenaddr+port [natengine|targetaddr+port|"sni"+port]. Multiple specs are allowed, one on each line.
 .SH "FILES"
 .LP 
 /etc/sslsplit/sslsplit.conf


### PR DESCRIPTION
Just a small improvement, as gcc (Ubuntu 7.3.0-16ubuntu3) 7.3.0 complains about missing breaks in case statements now:
```
privsep.c: In function ‘privsep_server_handle_req’:
privsep.c:314:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
   mkpath = 1;
   ~~~~~~~^~~
privsep.c:315:2: note: here
  case PRIVSEP_REQ_OPENFILE: {
  ^~~~
```