### PR TITLE
Add VerifyPeer and AllowWrongHost options to validate upstream certificates

### DIFF
--- a/opts.c
+++ b/opts.c
@@ -1366,13 +1366,13 @@ load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 			}
 			yes ? opts_set_verify_peer(opts) : opts_unset_verify_peer(opts);
 			fprintf(stderr, "VerifyPeer: %u\n", opts->verify_peer);
-		} else if (!strncasecmp(name, "AllowWrongHost", 15)) {
-			yes = check_value_yesno(value, "AllowWrongHost", line_num);
+		} else if (!strncasecmp(name, "AddSNIToCertificate", 20)) {
+			yes = check_value_yesno(value, "AddSNIToCertificate", line_num);
 			if (yes == -1) {
 				goto leave;
 			}
 			yes ? opts_set_allow_wrong_host(opts) : opts_unset_allow_wrong_host(opts);
-			fprintf(stderr, "AllowWrongHost: %u\n", opts->allow_wrong_host);
+			fprintf(stderr, "AddSNIToCertificate: %u\n", opts->allow_wrong_host);
 		} else {
 			fprintf(stderr, "Error in conf file: Unknown option '%s' at line %d\n", name, line_num);
 			goto leave;

--- a/opts.c
+++ b/opts.c
@@ -63,6 +63,7 @@ opts_new(void)
 	opts->sslcomp = 1;
 	opts->chain = sk_X509_new_null();
 	opts->sslmethod = SSLv23_method;
+	opts->allow_wrong_host = 1;
 
 	return opts;
 }
@@ -1108,6 +1109,30 @@ opts_unset_debug(opts_t *opts)
 	opts->debug = 0;
 }
 
+static void
+opts_set_verify_peer(opts_t *opts)
+{
+	opts->verify_peer = 1;
+}
+
+static void
+opts_unset_verify_peer(opts_t *opts)
+{
+	opts->verify_peer = 0;
+}
+
+static void
+opts_set_allow_wrong_host(opts_t *opts)
+{
+	opts->allow_wrong_host = 1;
+}
+
+static void
+opts_unset_allow_wrong_host(opts_t *opts)
+{
+	opts->allow_wrong_host = 0;
+}
+
 static int
 check_value_yesno(char *value, char *name, int line_num)
 {
@@ -1334,6 +1359,20 @@ load_conffile(opts_t *opts, const char *argv0, const char *prev_natengine)
 			
 			proxyspec_parse(&argc, &argv, natengine, &opts->spec);
 			free(save_argv);
+		} else if (!strncasecmp(name, "VerifyPeer", 11)) {
+			yes = check_value_yesno(value, "VerifyPeer", line_num);
+			if (yes == -1) {
+				goto leave;
+			}
+			yes ? opts_set_verify_peer(opts) : opts_unset_verify_peer(opts);
+			fprintf(stderr, "VerifyPeer: %u\n", opts->verify_peer);
+		} else if (!strncasecmp(name, "AllowWrongHost", 15)) {
+			yes = check_value_yesno(value, "AllowWrongHost", line_num);
+			if (yes == -1) {
+				goto leave;
+			}
+			yes ? opts_set_allow_wrong_host(opts) : opts_unset_allow_wrong_host(opts);
+			fprintf(stderr, "AllowWrongHost: %u\n", opts->allow_wrong_host);
 		} else {
 			fprintf(stderr, "Error in conf file: Unknown option '%s' at line %d\n", name, line_num);
 			goto leave;

--- a/opts.h
+++ b/opts.h
@@ -113,6 +113,8 @@ typedef struct opts {
 #endif /* !OPENSSL_NO_ECDH */
 	proxyspec_t *spec;
 	char *crlurl;
+	unsigned int verify_peer: 1;
+	unsigned int allow_wrong_host: 1;
 } opts_t;
 
 void NORET oom_die(const char *) NONNULL(1);

--- a/sslsplit.1
+++ b/sslsplit.1
@@ -82,7 +82,7 @@ is available, instead of generating forged ones.  SSLsplit supports NULL-prefix
 CN certificates but otherwise does not implement exploits against specific
 certificate verification vulnerabilities in SSL/TLS stacks.
 .LP
-SSLsplit implements a number of defences against mechanisms which would
+SSLsplit implements a number of defenses against mechanisms which would
 normally prevent MitM attacks or make them more difficult.
 SSLsplit can deny OCSP requests in a generic way.
 For HTTP and HTTPS connections, SSLsplit mangles headers to
@@ -240,7 +240,7 @@ parsable by OpenSSL, or if the method is \fBPOST\fP and the \fBContent-Type\fP
 is \fBapplication/ocsp-request\fP.
 For this to be effective, SSLsplit must be handling traffic destined to the
 port used by the OCSP server.  In particular, SSLsplit must be configured to
-receive traffic to all ports used by OCSP servers of targetted certificates
+receive traffic to all ports used by OCSP servers of targeted certificates
 within the \fIcertdir\fP specified by \fB-t\fP.
 .TP
 .B \-p \fIpidfile\fP
@@ -428,7 +428,7 @@ Use the Server Name Indication (SNI) hostname sent by the client in the
 Client Hello SSL/TLS message to determine the IP address of the server to
 connect to.  This only works for \fBssl\fP and \fBhttps\fP \fIproxyspecs\fP and
 needs a port or service name as an argument.
-Because this requires DNS lookups, it is preferrable to use NAT engine
+Because this requires DNS lookups, it is preferable to use NAT engine
 lookups (see above), except when that is not possible, such as when there is
 no supported NAT engine or when running \fBsslsplit\fP on a different system
 than the NAT rules redirecting the actual connections.
@@ -662,7 +662,7 @@ Intercepting IMAP/IMAPS using the same settings:
          tcp ::1 10143  tcp 127.0.0.1 10143\fP
 .fi
 .LP
-A more targetted setup, HTTPS only, using certificate/chain/key files from
+A more targeted setup, HTTPS only, using certificate/chain/key files from
 \fB/path/to/cert.d\fP and statically redirecting to \fBwww.example.org\fP
 instead of querying a NAT engine:
 .LP
@@ -724,7 +724,7 @@ authorityKeyIdentifier  = keyid:always,issuer:always
 SSLsplit is able to handle a relatively high number of listeners and
 connections due to a multithreaded, event based architecture based on libevent,
 taking advantage of platform specific select() replacements such as kqueue.
-The main thread handles the listeners and signalling, while a number of worker
+The main thread handles the listeners and signaling, while a number of worker
 threads equal to twice the number of CPU cores is used for handling the actual
 connections in separate event bases, including the CPU-intensive SSL/TLS
 handling.
@@ -733,7 +733,7 @@ Care has been taken to choose well-performing data structures for caching
 certificates and SSL sessions.  Logging is implemented in separate disk writer
 threads to ensure that socket event handling threads don't have to block on
 disk I/O.
-DNS lookups are performed asynchroniously.
+DNS lookups are performed asynchronously.
 SSLsplit uses SSL session caching on both ends to minimize the amount of full
 SSL handshakes, but even then, the limiting factor in handling SSL connections
 are the actual bignum computations.

--- a/sslsplit.1
+++ b/sslsplit.1
@@ -82,7 +82,7 @@ is available, instead of generating forged ones.  SSLsplit supports NULL-prefix
 CN certificates but otherwise does not implement exploits against specific
 certificate verification vulnerabilities in SSL/TLS stacks.
 .LP
-SSLsplit implements a number of defenses against mechanisms which would
+SSLsplit implements a number of defences against mechanisms which would
 normally prevent MitM attacks or make them more difficult.
 SSLsplit can deny OCSP requests in a generic way.
 For HTTP and HTTPS connections, SSLsplit mangles headers to
@@ -240,7 +240,7 @@ parsable by OpenSSL, or if the method is \fBPOST\fP and the \fBContent-Type\fP
 is \fBapplication/ocsp-request\fP.
 For this to be effective, SSLsplit must be handling traffic destined to the
 port used by the OCSP server.  In particular, SSLsplit must be configured to
-receive traffic to all ports used by OCSP servers of targeted certificates
+receive traffic to all ports used by OCSP servers of targetted certificates
 within the \fIcertdir\fP specified by \fB-t\fP.
 .TP
 .B \-p \fIpidfile\fP
@@ -428,7 +428,7 @@ Use the Server Name Indication (SNI) hostname sent by the client in the
 Client Hello SSL/TLS message to determine the IP address of the server to
 connect to.  This only works for \fBssl\fP and \fBhttps\fP \fIproxyspecs\fP and
 needs a port or service name as an argument.
-Because this requires DNS lookups, it is preferable to use NAT engine
+Because this requires DNS lookups, it is preferrable to use NAT engine
 lookups (see above), except when that is not possible, such as when there is
 no supported NAT engine or when running \fBsslsplit\fP on a different system
 than the NAT rules redirecting the actual connections.
@@ -662,7 +662,7 @@ Intercepting IMAP/IMAPS using the same settings:
          tcp ::1 10143  tcp 127.0.0.1 10143\fP
 .fi
 .LP
-A more targeted setup, HTTPS only, using certificate/chain/key files from
+A more targetted setup, HTTPS only, using certificate/chain/key files from
 \fB/path/to/cert.d\fP and statically redirecting to \fBwww.example.org\fP
 instead of querying a NAT engine:
 .LP
@@ -724,7 +724,7 @@ authorityKeyIdentifier  = keyid:always,issuer:always
 SSLsplit is able to handle a relatively high number of listeners and
 connections due to a multithreaded, event based architecture based on libevent,
 taking advantage of platform specific select() replacements such as kqueue.
-The main thread handles the listeners and signaling, while a number of worker
+The main thread handles the listeners and signalling, while a number of worker
 threads equal to twice the number of CPU cores is used for handling the actual
 connections in separate event bases, including the CPU-intensive SSL/TLS
 handling.
@@ -733,7 +733,7 @@ Care has been taken to choose well-performing data structures for caching
 certificates and SSL sessions.  Logging is implemented in separate disk writer
 threads to ensure that socket event handling threads don't have to block on
 disk I/O.
-DNS lookups are performed asynchronously.
+DNS lookups are performed asynchroniously.
 SSLsplit uses SSL session caching on both ends to minimize the amount of full
 SSL handshakes, but even then, the limiting factor in handling SSL connections
 are the actual bignum computations.

--- a/sslsplit.conf
+++ b/sslsplit.conf
@@ -96,8 +96,10 @@ Daemon yes
 # Verify peer using default certificates
 #VerifyPeer no
 
-# Allow wrong host names in certificates
-#AllowWrongHost yes
+# When disabled, never add the SNI to forged certificates, even if the SNI
+# provided by the client does not match the server certificate's CN/SAN.
+# Helps pass the wrong.host test at https://badssl.com.
+#AddSNIToCertificate yes
 
 # Proxy specifications
 # type listenaddr+port [natengine|targetaddr+port|"sni"+port]

--- a/sslsplit.conf
+++ b/sslsplit.conf
@@ -93,6 +93,12 @@ Daemon yes
 # Debug mode: run in foreground, log debug messages on stderr
 #Debug yes
 
+# Verify peer using default certificates
+#VerifyPeer no
+
+# Allow wrong host names in certificates
+#AllowWrongHost yes
+
 # Proxy specifications
 # type listenaddr+port [natengine|targetaddr+port|"sni"+port]
 ProxySpec https 127.0.0.1 8443

--- a/sslsplit.conf.5
+++ b/sslsplit.conf.5
@@ -152,6 +152,16 @@ Daemon mode: run in background, log error messages to syslog.
 .TP 
 \fBDebug BOOL\fR
 Debug mode: run in foreground, log debug messages on stderr.
+.TP
+\fBVerifyPeer BOOL\fR
+Verify peer using default certificates.
+.br
+Default: no
+.TP
+\fBAllowWrongHost BOOL\fR
+Allow wrong host names in certificates.
+.br
+Default: yes
 .TP 
 \fBProxySpec STRING\fR
 Proxy specification: type listenaddr+port [natengine|targetaddr+port|"sni"+port]. Multiple specs are allowed, one on each line.

--- a/sslsplit.conf.5
+++ b/sslsplit.conf.5
@@ -158,8 +158,8 @@ Verify peer using default certificates.
 .br
 Default: no
 .TP
-\fBAllowWrongHost BOOL\fR
-Allow wrong host names in certificates.
+\fBAddSNIToCertificate BOOL\fR
+When disabled, never add the SNI to forged certificates, even if the SNI provided by the client does not match the server certificate's CN/SAN. Helps pass the wrong.host test at https://badssl.com.
 .br
 Default: yes
 .TP 


### PR DESCRIPTION
This is my attempt to implement issue #80. I've been using this in my [SSLproxy](https://github.com/sonertari/SSLproxy) project for about 6 months now. I think VerifyPeer works well, but I am suspicious if AllowWrongHost option does what you actually want.

Also note that since we have conf file support now, I haven't created command line options for these.