### PR TITLE
Avoid race condition due to cert_free()

### DIFF
--- a/cert.c
+++ b/cert.c
@@ -204,8 +204,6 @@ cert_free(cert_t *c)
 		pthread_mutex_unlock(&c->mutex);
 		return;
 	}
-	pthread_mutex_unlock(&c->mutex);
-	pthread_mutex_destroy(&c->mutex);
 	if (c->key) {
 		EVP_PKEY_free(c->key);
 	}
@@ -215,6 +213,8 @@ cert_free(cert_t *c)
 	if (c->chain) {
 		sk_X509_pop_free(c->chain, X509_free);
 	}
+	pthread_mutex_unlock(&c->mutex);
+	pthread_mutex_destroy(&c->mutex);
 	free(c);
 }
 


### PR DESCRIPTION
Do not release lock especially until key is freed, otherwise we may get signal 6 crash at EVP_PKEY_free() call in libssl/ssl_rsa.c.

I've got a couple of such crashes recently, and was able to gdb rt the core file of a signal 6. Looking at the trace and debug logs, I have concluded that this happens when more than one thread gets "Certificate cache: HIT" for the same url at the same time: 4x threads going for www.aviationweather.gov in my case.

As it is hard to get this race condition, I am still testing this pr. But I couldn't see any side effects of unlocking the mutex at the exit of cert_free() yet.

Was there a reason for releasing the lock earlier? Any comments?