### PR TITLE
Add OpenSSL engine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /sslsplit
 /sslsplit.test
 /extra/*.pyc
+/extra/engine/*.dylib
+/extra/engine/*.so
 /extra/pki/dh*.param
 /extra/pki/dsa.pem
 /extra/pki/dsa.crt

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -352,6 +352,8 @@ endif
 
 export VERSION
 export OPENSSL
+export OPENSSL_BASE
+export OPENSSL_FOUND
 export MKDIR
 export WGET
 
@@ -409,6 +411,7 @@ travis: test
 test: TCPPFLAGS+=-D"TEST_ZEROUSR=\"$(shell id -u -n root||echo 0)\""
 test: TCPPFLAGS+=-D"TEST_ZEROGRP=\"$(shell id -g -n root||echo 0)\""
 test: $(TARGET).test
+	$(MAKE) -C extra/engine
 	$(RM) extra/pki/session.pem
 	$(MAKE) -C extra/pki testreqs session
 	./$(TARGET).test
@@ -453,7 +456,7 @@ mantest: $(TARGET).1
 	$(MAN) -M . 1 $(TARGET)
 	$(RM) man1
 
-copyright: *.c *.h *.1 *.5
+copyright: *.c *.h *.1 *.5 extra/engine/*.c
 	Mk/bin/copyright.py $^
 
 $(PKGNAME)-$(VERSION).1.txt: $(TARGET).1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -423,6 +423,7 @@ $(TARGET).test: $(TOBJS)
 	$(CC) $(LDFLAGS) $(TPKG_LDFLAGS) -o $@ $^ $(LIBS) $(TPKG_LIBS)
 
 clean:
+	$(MAKE) -C extra/engine clean
 	$(RM) -f $(TARGET) $(TARGET).test *.o .*.o *.core *~
 	$(RM) -rf *.dSYM
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 
 ### SSLsplit develop
 
+-   Add -x option for activating an OpenSSL engine (issue #204).
 -   Add -f option for loading configuration from file (pull req #193).
 -   Add `sudotest` target with unit tests which require privileges to run.
 -   Minor bugfixes and improvements.

--- a/extra/engine/GNUmakefile
+++ b/extra/engine/GNUmakefile
@@ -28,6 +28,6 @@ $(TARGET).$(SUFFIX): $(TARGET).c GNUmakefile
 	$(CC) -shared $(CFLAGS) $(LDFLAGS) -o $@ $< $(LIBS)
 
 clean:
-	rm -f $(OPENSSL_BASE).$(SUFFIX)
+	rm -f $(TARGET).$(SUFFIX)
 
 .PHONY: all clean

--- a/extra/engine/GNUmakefile
+++ b/extra/engine/GNUmakefile
@@ -1,0 +1,33 @@
+UNAME_S:=	$(shell uname -s)
+
+ifdef OPENSSL_FOUND
+OPENSSL_BASE=	$(OPENSSL_FOUND)
+else
+ifndef OPENSSL_BASE
+OPENSSL_BASE=	$(shell pkg-config --variable=prefix openssl)
+endif
+endif
+
+ifeq ($(UNAME_S),Darwin)
+SUFFIX:=	dylib
+#CFLAGS+=	-arch i386
+CFLAGS+=	-arch x86_64
+else
+SUFFIX:=	so
+endif
+
+CFLAGS+=	-fPIC -I$(OPENSSL_BASE)/include
+LDFLAGS+=	-L$(OPENSSL_BASE)/lib
+LIBS+=		-lcrypto
+
+TARGET=		dummy-engine
+
+all: $(TARGET).$(SUFFIX)
+
+$(TARGET).$(SUFFIX): $(TARGET).c GNUmakefile
+	$(CC) -shared $(CFLAGS) $(LDFLAGS) -o $@ $< $(LIBS)
+
+clean:
+	rm -f $(OPENSSL_BASE).$(SUFFIX)
+
+.PHONY: all clean

--- a/extra/engine/dummy-engine.c
+++ b/extra/engine/dummy-engine.c
@@ -1,0 +1,57 @@
+/*-
+ * SSLsplit - transparent SSL/TLS interception
+ * https://www.roe.ch/SSLsplit
+ *
+ * Copyright (c) 2009-2018, Daniel Roethlisberger <daniel@roe.ch>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Dummy OpenSSL engine.  Does not do anything useful except being loadable.
+ *
+ * gcc -I/opt/local/include -fPIC -o dummy-engine.o -c dummy-engine.c
+ * gcc -L/opt/local/lib -shared -o dummy-engine.dylib -lcrypto dummy-engine.o
+ * openssl engine -t -c `pwd`/dummy-engine.dylib
+ */
+
+#include <stdio.h>
+
+#include <openssl/engine.h>
+
+static int
+bind(ENGINE *engine, const char *id)
+{
+	if (!ENGINE_set_id(engine, "dummy")) {
+		fprintf(stderr, "ENGINE_set_id() failed\n");
+		return 0;
+	}
+	if (!ENGINE_set_name(engine, "dummy engine")) {
+		fprintf(stderr, "ENGINE_set_name() failed\n");
+		return 0;
+	}
+	return 1;
+}
+
+IMPLEMENT_DYNAMIC_BIND_FN(bind)
+IMPLEMENT_DYNAMIC_CHECK_FN()
+

--- a/extra/engine/dummy-engine.c
+++ b/extra/engine/dummy-engine.c
@@ -28,6 +28,7 @@
 
 /*
  * Dummy OpenSSL engine.  Does not do anything useful except being loadable.
+ * It deliberately builds fine even if engine support is unavailable.
  *
  * gcc -I/opt/local/include -fPIC -o dummy-engine.o -c dummy-engine.c
  * gcc -L/opt/local/lib -shared -o dummy-engine.dylib -lcrypto dummy-engine.o
@@ -36,6 +37,8 @@
 
 #include <stdio.h>
 
+#include <openssl/conf.h>
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
 
 static int
@@ -54,4 +57,5 @@ bind(ENGINE *engine, const char *id)
 
 IMPLEMENT_DYNAMIC_BIND_FN(bind)
 IMPLEMENT_DYNAMIC_CHECK_FN()
+#endif /* !OPENSSL_NO_ENGINE */
 

--- a/main.c
+++ b/main.c
@@ -163,7 +163,12 @@ main_usage(void)
 "  -r proto    only support one of " SSL_PROTO_SUPPORT_S "(default: all)\n"
 "  -R proto    disable one of " SSL_PROTO_SUPPORT_S "(default: none)\n"
 "  -s ciphers  use the given OpenSSL cipher suite spec (default: " DFLT_CIPHERS ")\n"
+#ifndef OPENSSL_NO_ENGINE
 "  -x engine   load OpenSSL engine with the given identifier\n"
+#define OPT_x "x:"
+#else /* OPENSSL_NO_ENGINE */
+#define OPT_x 
+#endif /* OPENSSL_NO_ENGINE */
 "  -e engine   specify default NAT engine to use (default: %s)\n"
 "  -E          list available NAT engines and exit\n"
 "  -u user     drop privileges to user (default if run as root: " DFLT_DROPUSER ")\n"
@@ -300,8 +305,9 @@ main(int argc, char *argv[])
 		natengine = NULL;
 	}
 
-	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z OPT_i "k:c:C:K:t:OPa:"
-	                    "b:s:r:R:x:e:Eu:m:j:p:l:L:S:F:M:dDVhW:w:q:f:o:")) != -1) {
+	while ((ch = getopt(argc, argv, OPT_g OPT_G OPT_Z OPT_i OPT_x
+	                    "k:c:C:K:t:OPa:b:s:r:R:e:Eu:m:j:p:l:L:S:F:M:"
+	                    "dDVhW:w:q:f:o:")) != -1) {
 		switch (ch) {
 			case 'f':
 				if (opts->conffile)
@@ -373,9 +379,11 @@ main(int argc, char *argv[])
 			case 'R':
 				opts_disable_proto(opts, argv0, optarg);
 				break;
+#ifndef OPENSSL_NO_ENGINE
 			case 'x':
 				opts_set_openssl_engine(opts, argv0, optarg);
 				break;
+#endif /* !OPENSSL_NO_ENGINE */
 			case 'e':
 				if (natengine)
 					free(natengine);
@@ -484,12 +492,14 @@ main(int argc, char *argv[])
 			                argv0);
 			exit(EXIT_FAILURE);
 		}
+#ifndef OPENSSL_NO_ENGINE
 		if (opts->openssl_engine &&
 		    ssl_engine(opts->openssl_engine) == -1) {
 			fprintf(stderr, "%s: failed to enable OpenSSL engine"
 			                " %s.\n", argv0, opts->openssl_engine);
 			exit(EXIT_FAILURE);
 		}
+#endif /* !OPENSSL_NO_ENGINE */
 		if ((opts->cacrt || !opts->tgcrtdir) && !opts->cakey) {
 			fprintf(stderr, "%s: no CA key specified (-k).\n",
 			                argv0);
@@ -629,10 +639,12 @@ main(int argc, char *argv[])
 			log_dbg_printf("- %s\n", specstr);
 			free(specstr);
 		}
+#ifndef OPENSSL_NO_ENGINE
 		if (opts->openssl_engine) {
 			log_dbg_printf("Loaded OpenSSL engine %s\n",
 			               opts->openssl_engine);
 		}
+#endif /* !OPENSSL_NO_ENGINE */
 		if (opts->cacrt) {
 			char *subj = ssl_x509_subject(opts->cacrt);
 			log_dbg_printf("Loaded CA: '%s'\n", subj);

--- a/opts.c
+++ b/opts.c
@@ -103,6 +103,9 @@ opts_free(opts_t *opts)
 	if (opts->ciphers) {
 		free(opts->ciphers);
 	}
+	if (opts->openssl_engine) {
+		free(opts->openssl_engine);
+	}
 	if (opts->tgcrtdir) {
 		free(opts->tgcrtdir);
 	}
@@ -751,6 +754,17 @@ opts_set_ciphers(opts_t *opts, const char *argv0, const char *optarg)
 	log_dbg_printf("Ciphers: %s\n", opts->ciphers);
 }
 
+void
+opts_set_openssl_engine(opts_t *opts, const char *argv0, const char *optarg)
+{
+	if (opts->openssl_engine)
+		free(opts->openssl_engine);
+	opts->openssl_engine = strdup(optarg);
+	if (!opts->openssl_engine)
+		oom_die(argv0);
+	log_dbg_printf("OpenSSLEngine: %s\n", opts->openssl_engine);
+}
+
 /*
  * Parse SSL proto string in optarg and look up the corresponding SSL method.
  * Calls exit() on failure.
@@ -1215,6 +1229,8 @@ set_option(opts_t *opts, const char *argv0, const char *name, char *value, char 
 		opts_disable_proto(opts, argv0, value);
 	} else if (!strncmp(name, "Ciphers", 8)) {
 		opts_set_ciphers(opts, argv0, value);
+	} else if (!strncmp(name, "OpenSSLEngine", 14)) {
+		opts_set_openssl_engine(opts, argv0, value);
 	} else if (!strncmp(name, "NATEngine", 10)) {
 		if (*natengine)
 			free(*natengine);

--- a/opts.c
+++ b/opts.c
@@ -103,9 +103,11 @@ opts_free(opts_t *opts)
 	if (opts->ciphers) {
 		free(opts->ciphers);
 	}
+#ifndef OPENSSL_NO_ENGINE
 	if (opts->openssl_engine) {
 		free(opts->openssl_engine);
 	}
+#endif /* !OPENSSL_NO_ENGINE */
 	if (opts->tgcrtdir) {
 		free(opts->tgcrtdir);
 	}
@@ -754,6 +756,7 @@ opts_set_ciphers(opts_t *opts, const char *argv0, const char *optarg)
 	log_dbg_printf("Ciphers: %s\n", opts->ciphers);
 }
 
+#ifndef OPENSSL_NO_ENGINE
 void
 opts_set_openssl_engine(opts_t *opts, const char *argv0, const char *optarg)
 {
@@ -764,6 +767,7 @@ opts_set_openssl_engine(opts_t *opts, const char *argv0, const char *optarg)
 		oom_die(argv0);
 	log_dbg_printf("OpenSSLEngine: %s\n", opts->openssl_engine);
 }
+#endif /* !OPENSSL_NO_ENGINE */
 
 /*
  * Parse SSL proto string in optarg and look up the corresponding SSL method.
@@ -1229,8 +1233,10 @@ set_option(opts_t *opts, const char *argv0, const char *name, char *value, char 
 		opts_disable_proto(opts, argv0, value);
 	} else if (!strncmp(name, "Ciphers", 8)) {
 		opts_set_ciphers(opts, argv0, value);
+#ifndef OPENSSL_NO_ENGINE
 	} else if (!strncmp(name, "OpenSSLEngine", 14)) {
 		opts_set_openssl_engine(opts, argv0, value);
+#endif /* !OPENSSL_NO_ENGINE */
 	} else if (!strncmp(name, "NATEngine", 10)) {
 		if (*natengine)
 			free(*natengine);

--- a/opts.h
+++ b/opts.h
@@ -83,6 +83,7 @@ typedef struct opts {
 	unsigned int lprocinfo : 1;
 #endif /* HAVE_LOCAL_PROCINFO */
 	unsigned int certgen_writeall: 1;
+	char *openssl_engine;
 	char *ciphers;
 	char *certgendir;
 	char *tgcrtdir;
@@ -154,6 +155,8 @@ void opts_unset_sslcomp(opts_t *) NONNULL(1);
 void opts_force_proto(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_disable_proto(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_ciphers(opts_t *, const char *, const char *) NONNULL(1,2,3);
+void opts_set_openssl_engine(opts_t *, const char *, const char *)
+     NONNULL(1,2,3);
 void opts_set_user(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_group(opts_t *, const char *, const char *) NONNULL(1,2,3);
 void opts_set_jaildir(opts_t *, const char *, const char *) NONNULL(1,2,3);

--- a/opts.h
+++ b/opts.h
@@ -83,7 +83,9 @@ typedef struct opts {
 	unsigned int lprocinfo : 1;
 #endif /* HAVE_LOCAL_PROCINFO */
 	unsigned int certgen_writeall: 1;
+#ifndef OPENSSL_NO_ENGINE
 	char *openssl_engine;
+#endif /* !OPENSSL_NO_ENGINE */
 	char *ciphers;
 	char *certgendir;
 	char *tgcrtdir;

--- a/ssl.c
+++ b/ssl.c
@@ -373,7 +373,7 @@ ssl_init(void)
 #ifndef OPENSSL_NO_ENGINE
 	                    |OPENSSL_INIT_ENGINE_ALL_BUILTIN
 #endif /* !OPENSSL_NO_ENGINE */
-	                   );
+	                    , NULL);
 	OPENSSL_init_ssl(0, NULL);
 #else /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 	SSL_library_init();

--- a/ssl.c
+++ b/ssl.c
@@ -531,12 +531,7 @@ ssl_engine(const char *name) {
 		return -1;
 	return 0;
 }
-#else /* OPENSSL_NO_ENGINE */
-int
-ssl_engine(UNUSED const char *name) {
-	return -1;
-}
-#endif /* OPENSSL_NO_ENGINE */
+#endif /* !OPENSSL_NO_ENGINE */
 
 /*
  * Format raw SHA1 hash into newly allocated string, with or without colons.

--- a/ssl.c
+++ b/ssl.c
@@ -374,8 +374,11 @@ ssl_init(void)
 	                    |OPENSSL_INIT_ENGINE_ALL_BUILTIN
 #endif /* !OPENSSL_NO_ENGINE */
 	                   );
-#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+	OPENSSL_init_ssl(0, NULL);
+#else /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 	SSL_library_init();
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+
 #ifdef PURIFY
 	CRYPTO_malloc_init();
 	CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);

--- a/ssl.c
+++ b/ssl.c
@@ -450,19 +450,6 @@ ssl_reinit(void)
 	return 0;
 }
 
-int
-ssl_engine(const char *name) {
-	ENGINE *engine;
-
-	engine = ENGINE_by_id(name);
-	if (!engine)
-		return -1;
-
-	if (!ENGINE_set_default(engine, ENGINE_METHOD_ALL))
-		return -1;
-	return 0;
-}
-
 /*
  * Deinitialize OpenSSL and free as much memory as possible.
  * Some 10k-100k will still remain resident no matter what.
@@ -501,6 +488,25 @@ ssl_fini(void)
 	EVP_cleanup();
 	ERR_free_strings();
 	CRYPTO_cleanup_all_ex_data();
+}
+
+/*
+ * Look up an OpenSSL engine by ID or by full path and load it as default
+ * engine.  This works globally, not on specific SSL_CTX or SSL instances.
+ * OpenSSL must already have been initialized when calling this function.
+ * Returns 0 on success, -1 on failure.
+ */
+int
+ssl_engine(const char *name) {
+	ENGINE *engine;
+
+	engine = ENGINE_by_id(name);
+	if (!engine)
+		return -1;
+
+	if (!ENGINE_set_default(engine, ENGINE_METHOD_ALL))
+		return -1;
+	return 0;
 }
 
 /*

--- a/ssl.c
+++ b/ssl.c
@@ -367,7 +367,9 @@ ssl_init(void)
 #endif /* PURIFY */
 	SSL_load_error_strings();
 	OpenSSL_add_all_algorithms();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	OPENSSL_config(NULL);
+#endif
 
 	/* thread-safety */
 #if defined(OPENSSL_THREADS) && OPENSSL_VERSION_NUMBER < 0x10100000L

--- a/ssl.c
+++ b/ssl.c
@@ -490,7 +490,7 @@ ssl_fini(void)
 	free(ssl_mutex);
 #endif
 
-#ifndef OPENSSL_NO_ENGINE
+#if !defined(OPENSSL_NO_ENGINE) && OPENSSL_VERSION_NUMBER < 0x10100000L
 	ENGINE_cleanup();
 #endif /* OPENSSL_NO_ENGINE */
 	CONF_modules_finish();

--- a/ssl.c
+++ b/ssl.c
@@ -40,7 +40,9 @@
 #include <limits.h>
 
 #include <openssl/crypto.h>
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif /* OPENSSL_NO_ENGINE */
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>

--- a/ssl.c
+++ b/ssl.c
@@ -367,6 +367,7 @@ ssl_init(void)
 #endif /* PURIFY */
 	SSL_load_error_strings();
 	OpenSSL_add_all_algorithms();
+	OPENSSL_config(NULL);
 
 	/* thread-safety */
 #if defined(OPENSSL_THREADS) && OPENSSL_VERSION_NUMBER < 0x10100000L
@@ -446,6 +447,19 @@ ssl_reinit(void)
 	}
 #endif /* OPENSSL_THREADS */
 
+	return 0;
+}
+
+int
+ssl_engine(const char *name) {
+	ENGINE *engine;
+
+	engine = ENGINE_by_id(name);
+	if (!engine)
+		return -1;
+
+	if (!ENGINE_set_default(engine, ENGINE_METHOD_ALL))
+		return -1;
 	return 0;
 }
 

--- a/ssl.c
+++ b/ssl.c
@@ -30,6 +30,7 @@
 
 #include "log.h"
 #include "defaults.h"
+#include "attrib.h"
 
 #include <sys/types.h>
 #include <fcntl.h>
@@ -168,6 +169,11 @@ ssl_openssl_version(void)
 #else /* !OPENSSL_THREADS */
 	fprintf(stderr, "OpenSSL is not thread-safe\n");
 #endif /* !OPENSSL_THREADS */
+#ifndef OPENSSL_NO_ENGINE
+	fprintf(stderr, "OpenSSL has engine support\n");
+#else /* !OPENSSL_NO_ENGINE */
+	fprintf(stderr, "OpenSSL has no engine support\n");
+#endif /* !OPENSSL_NO_ENGINE */
 #ifdef SSL_MODE_RELEASE_BUFFERS
 	fprintf(stderr, "Using SSL_MODE_RELEASE_BUFFERS\n");
 #else /* !SSL_MODE_RELEASE_BUFFERS */
@@ -482,7 +488,9 @@ ssl_fini(void)
 	free(ssl_mutex);
 #endif
 
+#ifndef OPENSSL_NO_ENGINE
 	ENGINE_cleanup();
+#endif /* OPENSSL_NO_ENGINE */
 	CONF_modules_finish();
 	CONF_modules_unload(1);
 	CONF_modules_free();
@@ -498,6 +506,7 @@ ssl_fini(void)
  * OpenSSL must already have been initialized when calling this function.
  * Returns 0 on success, -1 on failure.
  */
+#ifndef OPENSSL_NO_ENGINE
 int
 ssl_engine(const char *name) {
 	ENGINE *engine;
@@ -510,6 +519,12 @@ ssl_engine(const char *name) {
 		return -1;
 	return 0;
 }
+#else /* !OPENSSL_NO_ENGINE */
+int
+ssl_engine(UNUSED const char *name) {
+	return -1;
+}
+#endif /* !OPENSSL_NO_ENGINE */
 
 /*
  * Format raw SHA1 hash into newly allocated string, with or without colons.

--- a/ssl.h
+++ b/ssl.h
@@ -164,7 +164,9 @@ int ssl_init(void) WUNRES;
 int ssl_reinit(void) WUNRES;
 void ssl_fini(void);
 
+#ifndef OPENSSL_NO_ENGINE
 int ssl_engine(const char *) WUNRES;
+#endif /* !OPENSSL_NO_ENGINE */
 
 char * ssl_sha1_to_str(unsigned char *, int) NONNULL(1) MALLOC;
 

--- a/ssl.h
+++ b/ssl.h
@@ -164,6 +164,8 @@ int ssl_init(void) WUNRES;
 int ssl_reinit(void) WUNRES;
 void ssl_fini(void);
 
+int ssl_engine(const char *) WUNRES;
+
 char * ssl_sha1_to_str(unsigned char *, int) NONNULL(1) MALLOC;
 
 char * ssl_ssl_state_to_str(SSL *) NONNULL(1) MALLOC;

--- a/ssl.h
+++ b/ssl.h
@@ -38,6 +38,15 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+/*
+ * LibreSSL seems to ship engine support on a source code level, but it seems
+ * to be broken.  Tested with LibreSSL 2.7.4 on OpenBSD and macOS.  For now,
+ * disable engine support when building against LibreSSL.
+ */
+#if defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ENGINE)
+#define OPENSSL_NO_ENGINE
+#endif
+
 #if (OPENSSL_VERSION_NUMBER < 0x10000000L) && !defined(OPENSSL_NO_THREADID)
 #define OPENSSL_NO_THREADID
 #endif

--- a/ssl.t.c
+++ b/ssl.t.c
@@ -35,9 +35,16 @@
 
 #include <check.h>
 
+#ifdef __APPLE__
+#define DLSUFFIX "dylib"
+#else
+#define DLSUFFIX "so"
+#endif
+
 #define TESTKEY "extra/pki/server.key"
 #define TESTCERT "extra/pki/server.crt"
 #define TESTCERT2 "extra/pki/rsa.crt"
+#define ENGINE "extra/engine/dummy-engine."DLSUFFIX
 
 static void
 ssl_setup(void)
@@ -755,15 +762,9 @@ START_TEST(ssl_engine_01)
 	char cwd[PATH_MAX];
 	char *path;
 
-#ifdef __APPLE__
-#define DLSUFFIX "dylib"
-#else
-#define DLSUFFIX "so"
-#endif
-
 	fail_unless(getcwd(cwd, sizeof(cwd)) == cwd, "getcwd() failed");
-	UNUSED int unused = asprintf(&path, "%s/extra/engine/dummy-engine."DLSUFFIX, cwd);
-	fail_unless(!!path, "constructing engine path failed");
+	fail_unless(asprintf(&path, "%s/"ENGINE, cwd) != -1 && !!path,
+	            "constructing engine path failed");
 	fail_unless(ssl_engine(path) == 0, "loading OpenSSL engine failed");
 	free(path);
 }

--- a/ssl.t.c
+++ b/ssl.t.c
@@ -29,6 +29,7 @@
 #include "base64.h"
 #include "ssl.h"
 
+#include <limits.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -761,7 +762,7 @@ START_TEST(ssl_engine_01)
 #endif
 
 	fail_unless(getcwd(cwd, sizeof(cwd)) == cwd, "getcwd() failed");
-	(void)asprintf(&path, "%s/extra/engine/dummy-engine."DLSUFFIX, cwd);
+	UNUSED int unused = asprintf(&path, "%s/extra/engine/dummy-engine."DLSUFFIX, cwd);
 	fail_unless(!!path, "constructing engine path failed");
 	fail_unless(ssl_engine(path) == 0, "loading OpenSSL engine failed");
 	free(path);

--- a/ssl.t.c
+++ b/ssl.t.c
@@ -751,6 +751,7 @@ END_TEST
 
 START_TEST(ssl_engine_01)
 {
+	char cwd[PATH_MAX];
 	char *path;
 
 #ifdef __APPLE__
@@ -758,7 +759,9 @@ START_TEST(ssl_engine_01)
 #else
 #define DLSUFFIX "so"
 #endif
-	asprintf(&path, "%s/extra/engine/dummy-engine."DLSUFFIX, getwd(NULL));
+
+	fail_unless(getcwd(cwd, sizeof(cwd)) == cwd, "getcwd() failed");
+	(void)asprintf(&path, "%s/extra/engine/dummy-engine."DLSUFFIX, cwd);
 	fail_unless(!!path, "constructing engine path failed");
 	fail_unless(ssl_engine(path) == 0, "loading OpenSSL engine failed");
 }

--- a/ssl.t.c
+++ b/ssl.t.c
@@ -757,6 +757,7 @@ START_TEST(ssl_x509_refcount_inc_01)
 }
 END_TEST
 
+#ifndef OPENSSL_NO_ENGINE
 START_TEST(ssl_engine_01)
 {
 	char cwd[PATH_MAX];
@@ -769,6 +770,7 @@ START_TEST(ssl_engine_01)
 	free(path);
 }
 END_TEST
+#endif /* !OPENSSL_NO_ENGINE */
 
 Suite *
 ssl_suite(void)
@@ -873,10 +875,15 @@ ssl_suite(void)
 	tcase_add_test(tc, ssl_x509_refcount_inc_01);
 	suite_add_tcase(s, tc);
 
+#ifndef OPENSSL_NO_ENGINE
 	tc = tcase_create("ssl_engine");
 	tcase_add_checked_fixture(tc, ssl_setup, ssl_teardown);
 	tcase_add_test(tc, ssl_engine_01);
 	suite_add_tcase(s, tc);
+#else /* OPENSSL_NO_ENGINE */
+	fprintf(stderr, "1 test omitted because OpenSSL has no "
+	                "engine support\n");
+#endif /* OPENSSL_NO_ENGINE */
 
 	return s;
 }

--- a/ssl.t.c
+++ b/ssl.t.c
@@ -764,6 +764,7 @@ START_TEST(ssl_engine_01)
 	(void)asprintf(&path, "%s/extra/engine/dummy-engine."DLSUFFIX, cwd);
 	fail_unless(!!path, "constructing engine path failed");
 	fail_unless(ssl_engine(path) == 0, "loading OpenSSL engine failed");
+	free(path);
 }
 END_TEST
 

--- a/ssl.t.c
+++ b/ssl.t.c
@@ -30,6 +30,7 @@
 #include "ssl.h"
 
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <check.h>
 
@@ -748,6 +749,21 @@ START_TEST(ssl_x509_refcount_inc_01)
 }
 END_TEST
 
+START_TEST(ssl_engine_01)
+{
+	char *path;
+
+#ifdef __APPLE__
+#define DLSUFFIX "dylib"
+#else
+#define DLSUFFIX "so"
+#endif
+	asprintf(&path, "%s/extra/engine/dummy-engine."DLSUFFIX, getwd(NULL));
+	fail_unless(!!path, "constructing engine path failed");
+	fail_unless(ssl_engine(path) == 0, "loading OpenSSL engine failed");
+}
+END_TEST
+
 Suite *
 ssl_suite(void)
 {
@@ -849,6 +865,11 @@ ssl_suite(void)
 	tc = tcase_create("ssl_x509_refcount_inc");
 	tcase_add_checked_fixture(tc, ssl_setup, ssl_teardown);
 	tcase_add_test(tc, ssl_x509_refcount_inc_01);
+	suite_add_tcase(s, tc);
+
+	tc = tcase_create("ssl_engine");
+	tcase_add_checked_fixture(tc, ssl_setup, ssl_teardown);
+	tcase_add_test(tc, ssl_engine_01);
 	suite_add_tcase(s, tc);
 
 	return s;

--- a/sslsplit.1
+++ b/sslsplit.1
@@ -344,6 +344,8 @@ identifier, that is, they must be loaded from the global OpenSSL configuration.
 If \fIengine\fP is an absolute path, it will be interpreted as path to an
 engine dynamically linked library and loaded by path, regardless of global
 OpenSSL configuration.
+This option is only available if built against a version of OpenSSL with engine
+support.
 .TP
 .B \-V
 Display version and compiled features information and exit.

--- a/sslsplit.1
+++ b/sslsplit.1
@@ -30,18 +30,18 @@ sslsplit \-\- transparent SSL/TLS interception
 .SH SYNOPSIS
 .na
 .B sslsplit
-[\fB-kCKqwWOPZdDgGsrReumjplLSFiMab\fP] \fB-c\fP \fIpem\fP
+[\fB-kCKqwWOPZdDgGsrRxeumjplLSFiMab\fP] \fB-c\fP \fIpem\fP
 \fIproxyspecs\fP [...]
 .br
 .B sslsplit
-[\fB-kCKqwWOPZdDgGsrReumjplLSFiMab\fP] \fB-c\fP \fIpem\fP \fB-t\fP \fIdir\fP
+[\fB-kCKqwWOPZdDgGsrRxeumjplLSFiMab\fP] \fB-c\fP \fIpem\fP \fB-t\fP \fIdir\fP
 \fIproxyspecs\fP [...]
 .br
 .B sslsplit
-[\fB-OPZwWdDgGsrReumjplLSFiMab\fP] \fB-t\fP \fIdir\fP
+[\fB-OPZwWdDgGsrRxeumjplLSFiMab\fP] \fB-t\fP \fIdir\fP
 \fIproxyspecs\fP [...]
 .br
-.B sslsplit [\fB-kCKwWOPZdDgGsrReumjplLSFiM\fP] -f \fIconffile\fP
+.B sslsplit [\fB-kCKwWOPZdDgGsrRxeumjplLSFiM\fP] -f \fIconffile\fP
 .br
 .B sslsplit -E
 .br
@@ -336,6 +336,14 @@ The user needs to be allowed to make outbound TCP connections, and in some
 configurations, also to perform DNS resolution.
 Due to an Apple bug, \fB-u\fP cannot be used with \fBpf\fP proxyspecs on
 Mac OS X.
+.TP
+.B \-x \fIengine\fP
+Use the OpenSSL engine with identifier \fIengine\fP as a default engine.  The
+engine must be available within the OpenSSL ecosystem under the specified
+identifier, that is, they must be loaded from the global OpenSSL configuration.
+If \fIengine\fP is an absolute path, it will be interpreted as path to an
+engine dynamically linked library and loaded by path, regardless of global
+OpenSSL configuration.
 .TP
 .B \-V
 Display version and compiled features information and exit.

--- a/sslsplit.conf
+++ b/sslsplit.conf
@@ -56,6 +56,9 @@ CAKey /etc/sslsplit/ca.key
 # Use the given OpenSSL cipher suite spec (default: ALL:-aNULL)
 Ciphers MEDIUM:HIGH
 
+# OpenSSL engine to activate, either ID or full path to shared library
+#OpenSSLEngine cloudhsm
+
 # Specify default NAT engine to use
 #NATEngine netfilter
 

--- a/sslsplit.conf.5
+++ b/sslsplit.conf.5
@@ -111,6 +111,11 @@ Use the given OpenSSL cipher suite spec.
 .br 
 Default: ALL:-aNULL
 .TP 
+\fBOpenSSLEngine STRING\fR
+The OpenSSL engine to activate, either the ID or the full path to the shared
+library implementing the engine.  If an ID is given, the engine needs to be
+known to the system-wide OpenSSL configuration.
+.TP 
 \fBNATEngine STRING\fR
 Specify default NAT engine to use.
 .TP 

--- a/sslsplit.conf.5
+++ b/sslsplit.conf.5
@@ -114,7 +114,8 @@ Default: ALL:-aNULL
 \fBOpenSSLEngine STRING\fR
 The OpenSSL engine to activate, either the ID or the full path to the shared
 library implementing the engine.  If an ID is given, the engine needs to be
-known to the system-wide OpenSSL configuration.
+known to the system-wide OpenSSL configuration.  Only available if built
+against a version of OpenSSL with engine support.
 .TP 
 \fBNATEngine STRING\fR
 Specify default NAT engine to use.


### PR DESCRIPTION
Add the `-x` option to load and/or activate an OpenSSL engine. See issue #204 for a use case (AWS CloudHSM) and discussion.