### PR TITLE
Use interface MTU for mirroring

### DIFF
--- a/log.c
+++ b/log.c
@@ -603,8 +603,8 @@ log_content_format_pathspec(const char *logspec,
  */
 int
 log_content_open(log_content_ctx_t *ctx, opts_t *opts,
-                 const struct sockaddr *srcaddr,
-                 const struct sockaddr *dstaddr,
+                 const struct sockaddr *srcaddr, socklen_t srcaddrlen,
+                 const struct sockaddr *dstaddr, socklen_t dstaddrlen,
                  char *srchost, char *srcport,
                  char *dsthost, char *dstport,
                  char *exec_path, char *user, char *group)
@@ -708,7 +708,7 @@ log_content_open(log_content_ctx_t *ctx, opts_t *opts,
 
 		logpkt_ctx_init(&ctx->pcap->state, NULL, 0,
 		                content_pcap_src_ether, content_pcap_dst_ether,
-		                srcaddr, dstaddr);
+		                srcaddr, srcaddrlen, dstaddr, dstaddrlen);
 
 		if (opts->pcaplog_isdir) {
 			/* per-connection-file pcap log (-Y) */
@@ -749,7 +749,7 @@ log_content_open(log_content_ctx_t *ctx, opts_t *opts,
 		                content_mirror_mtu,
 		                content_mirror_src_ether,
 		                content_mirror_dst_ether,
-		                srcaddr, dstaddr);
+		                srcaddr, srcaddrlen, dstaddr, dstaddrlen);
 	}
 
 	/* submit open events */

--- a/log.h
+++ b/log.h
@@ -80,7 +80,8 @@ struct log_content_ctx {
 	struct log_content_mirror_ctx *mirror;
 };
 int log_content_open(log_content_ctx_t *, opts_t *,
-                     const struct sockaddr *, const struct sockaddr *,
+                     const struct sockaddr *, socklen_t,
+                     const struct sockaddr *, socklen_t,
                      char *, char *, char *, char *,
                      char *, char *, char *) NONNULL(1,2,3) WUNRES;
 int log_content_submit(log_content_ctx_t *, logbuf_t *, int)

--- a/logpkt.c
+++ b/logpkt.c
@@ -172,9 +172,9 @@ typedef struct __attribute__((packed)) {
 		(C) = ~(C); \
 	}
 
-#define CSA(X)          ((const struct sockaddr *)(&X))
-#define CSIN(X)         ((const struct sockaddr_in *)(&X))
-#define CSIN6(X)        ((const struct sockaddr_in6 *)(&X))
+#define CSA(X)          ((const struct sockaddr *)(X))
+#define CSIN(X)         ((const struct sockaddr_in *)(X))
+#define CSIN6(X)        ((const struct sockaddr_in6 *)(X))
 
 static int
 logpkt_write_global_pcap_hdr(int fd)
@@ -456,16 +456,16 @@ logpkt_write_packet(logpkt_ctx_t *ctx, int fd, int direction, char flags,
 		if (direction == LOGPKT_REQUEST) {
 			sz = logpkt_pcap_build(buf,
 			                       ctx->src_ether, ctx->dst_ether,
-			                       CSA(ctx->src_addr),
-			                       CSA(ctx->dst_addr),
+			                       CSA(&ctx->src_addr),
+			                       CSA(&ctx->dst_addr),
 			                       flags,
 			                       ctx->src_seq, ctx->dst_seq,
 			                       payload, payloadlen);
 		} else {
 			sz = logpkt_pcap_build(buf,
 			                       ctx->dst_ether, ctx->src_ether,
-			                       CSA(ctx->dst_addr),
-			                       CSA(ctx->src_addr),
+			                       CSA(&ctx->dst_addr),
+			                       CSA(&ctx->src_addr),
 			                       flags,
 			                       ctx->dst_seq, ctx->src_seq,
 			                       payload, payloadlen);
@@ -482,16 +482,16 @@ logpkt_write_packet(logpkt_ctx_t *ctx, int fd, int direction, char flags,
 		if (direction == LOGPKT_REQUEST) {
 			rv = logpkt_mirror_build(ctx->libnet,
 			                         ctx->src_ether, ctx->dst_ether,
-			                         CSA(ctx->src_addr),
-			                         CSA(ctx->dst_addr),
+			                         CSA(&ctx->src_addr),
+			                         CSA(&ctx->dst_addr),
 			                         flags,
 			                         ctx->src_seq, ctx->dst_seq,
 			                         payload, payloadlen);
 		} else {
 			rv = logpkt_mirror_build(ctx->libnet,
 			                         ctx->src_ether, ctx->dst_ether,
-			                         CSA(ctx->dst_addr),
-			                         CSA(ctx->src_addr),
+			                         CSA(&ctx->dst_addr),
+			                         CSA(&ctx->src_addr),
 			                         flags,
 			                         ctx->dst_seq, ctx->src_seq,
 			                         payload, payloadlen);

--- a/logpkt.h
+++ b/logpkt.h
@@ -40,8 +40,8 @@ typedef struct {
 	libnet_t *libnet;
 	uint8_t src_ether[ETHER_ADDR_LEN];
 	uint8_t dst_ether[ETHER_ADDR_LEN];
-	const struct sockaddr *src_addr;
-	const struct sockaddr *dst_addr;
+	struct sockaddr_storage src_addr;
+	struct sockaddr_storage dst_addr;
 	uint32_t src_seq;
 	uint32_t dst_seq;
 	size_t mss;
@@ -53,7 +53,8 @@ typedef struct {
 int logpkt_pcap_open_fd(int fd) WUNRES;
 void logpkt_ctx_init(logpkt_ctx_t *, libnet_t *, size_t,
                      const uint8_t *, const uint8_t *,
-                     const struct sockaddr *, const struct sockaddr *);
+                     const struct sockaddr *, socklen_t,
+                     const struct sockaddr *, socklen_t);
 int logpkt_write_payload(logpkt_ctx_t *, int, int,
                          const unsigned char *, size_t) WUNRES;
 int logpkt_write_close(logpkt_ctx_t *, int, int);

--- a/logpkt.h
+++ b/logpkt.h
@@ -51,7 +51,7 @@ typedef struct {
 #define LOGPKT_RESPONSE 1
 
 int logpkt_pcap_open_fd(int fd) WUNRES;
-void logpkt_ctx_init(logpkt_ctx_t *, libnet_t *,
+void logpkt_ctx_init(logpkt_ctx_t *, libnet_t *, size_t,
                      const uint8_t *, const uint8_t *,
                      const struct sockaddr *, const struct sockaddr *);
 int logpkt_write_payload(logpkt_ctx_t *, int, int,

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -1987,7 +1987,9 @@ pxy_bev_eventcb(struct bufferevent *bev, short events, void *arg)
 		if (WANT_CONTENT_LOG(ctx)) {
 			if (log_content_open(&ctx->logctx, ctx->opts,
 			                     (struct sockaddr *)&ctx->srcaddr,
+			                     ctx->srcaddrlen,
 			                     (struct sockaddr *)&ctx->dstaddr,
+			                     ctx->dstaddrlen,
 			                     ctx->srchost_str, ctx->srcport_str,
 			                     ctx->dsthost_str, ctx->dstport_str,
 #ifdef HAVE_LOCAL_PROCINFO

--- a/sys.h
+++ b/sys.h
@@ -52,6 +52,7 @@ int sys_sockaddr_parse(struct sockaddr_storage *, socklen_t *,
 int sys_sockaddr_str(struct sockaddr *, socklen_t,
                      char **, char **) NONNULL(1,3,4);
 char * sys_ip46str_sanitize(const char *) NONNULL(1) MALLOC;
+size_t sys_get_mtu(const char *);
 
 int sys_isdir(const char *) NONNULL(1) WUNRES;
 int sys_mkpath(const char *, mode_t) NONNULL(1) WUNRES;


### PR DESCRIPTION
For content logging to a mirror interface and destination IP, calculate an appropriate MSS based on the interface MTU instead of using a hardcoded value.

Main reason I am asking for a review is that I am not 100% sure how portable `ioctl(SIOCGIFMTU)` is in practice, but as usual please also object if you disagree with the idea of maxing out the MSS based on the interface MTU of the mirror target interface or if something else is amiss.