### PR TITLE
Fix runtime libnet version on OpenBSD and clean up

### DIFF
--- a/logpkt.c
+++ b/logpkt.c
@@ -46,10 +46,6 @@
 #include <pcap.h>
 #endif /* !WITHOUT_MIRROR */
 
-#if defined(__OpenBSD__) && !defined(ETHERTYPE_IPV6)
-#include <net/ethertypes.h>
-#endif /* __OpenBSD__ && !ETHERTYPE_IPV6 */
-
 typedef struct __attribute__((packed)) {
 	uint32_t magic_number;  /* magic number */
 	uint16_t version_major; /* major version number */

--- a/main.c
+++ b/main.c
@@ -119,10 +119,14 @@ main_version(void)
 	fprintf(stderr, "rtlinked against libevent %s\n", event_get_version());
 #ifndef WITHOUT_MIRROR
 	fprintf(stderr, "compiled against libnet %s\n", LIBNET_VERSION);
+#ifndef __OpenBSD__
 	const char *lnv = libnet_version();
 	if (!strncmp(lnv, "libnet version ", 15))
 		lnv += 15;
 	fprintf(stderr, "rtlinked against libnet %s\n", lnv);
+#else /* __OpenBSD__ */
+	fprintf(stderr, "rtlinked against libnet n/a\n");
+#endif /* __OpenBSD__ */
 	fprintf(stderr, "compiled against libpcap n/a\n");
 	const char *lpv = pcap_lib_version();
 	if (!strncmp(lpv, "libpcap version ", 16))


### PR DESCRIPTION
So sslsplit on OpenBSD prints now:
```
compiled against libnet 1.1.2.1
rtlinked against libnet n/a
compiled against libpcap n/a
rtlinked against libpcap OpenBSD libpcap
```