### PR TITLE
Store realpath of single log files to opts

### DIFF
--- a/log.c
+++ b/log.c
@@ -194,9 +194,8 @@ log_masterkey_preinit(const char *logfile)
 		               logfile, strerror(errno), errno);
 		return -1;
 	}
-	if (!(masterkey_fn = realpath(logfile, NULL))) {
-		log_err_printf("Failed to realpath '%s': %s (%i)\n",
-		              logfile, strerror(errno), errno);
+	masterkey_fn = strdup(logfile);
+	if (!masterkey_fn) {
 		close(masterkey_fd);
 		masterkey_fd = -1;
 		return -1;
@@ -262,9 +261,8 @@ log_connect_preinit(const char *logfile)
 		               logfile, strerror(errno), errno);
 		return -1;
 	}
-	if (!(connect_fn = realpath(logfile, NULL))) {
-		log_err_printf("Failed to realpath '%s': %s (%i)\n",
-		              logfile, strerror(errno), errno);
+	connect_fn = strdup(logfile);
+	if (!connect_fn) {
 		close(connect_fd);
 		connect_fd = -1;
 		return -1;
@@ -1028,9 +1026,8 @@ log_content_file_single_preinit(const char *logfile)
 		               logfile, strerror(errno), errno);
 		return -1;
 	}
-	if (!(content_file_single_fn = realpath(logfile, NULL))) {
-		log_err_printf("Failed to realpath '%s': %s (%i)\n",
-		              logfile, strerror(errno), errno);
+	content_file_single_fn = strdup(logfile);
+	if (!content_file_single_fn) {
 		close(content_file_single_fd);
 		content_file_single_fd = -1;
 		return -1;
@@ -1180,10 +1177,8 @@ log_content_pcap_preinit(const char *pcapfile)
 		content_pcap_fd = -1;
 		return -1;
 	}
-
-	if (!(content_pcap_fn = realpath(pcapfile, NULL))) {
-		log_err_printf("Failed to realpath '%s': %s (%i)\n",
-		               pcapfile, strerror(errno), errno);
+	content_pcap_fn = strdup(pcapfile);
+	if (!content_pcap_fn) {
 		close(content_pcap_fd);
 		content_pcap_fd = -1;
 		return -1;

--- a/opts.c
+++ b/opts.c
@@ -983,9 +983,11 @@ opts_set_connectlog(opts_t *opts, const char *argv0, const char *optarg)
 {
 	if (opts->connectlog)
 		free(opts->connectlog);
-	opts->connectlog = strdup(optarg);
-	if (!opts->connectlog)
+	if (!(opts->connectlog = realpath(optarg, NULL))) {
+		fprintf(stderr, "Failed to realpath '%s': %s (%i)\n",
+		              optarg, strerror(errno), errno);
 		oom_die(argv0);
+	}
 #ifdef DEBUG_OPTS
 	log_dbg_printf("ConnectLog: %s\n", opts->connectlog);
 #endif /* DEBUG_OPTS */
@@ -996,9 +998,11 @@ opts_set_contentlog(opts_t *opts, const char *argv0, const char *optarg)
 {
 	if (opts->contentlog)
 		free(opts->contentlog);
-	opts->contentlog = strdup(optarg);
-	if (!opts->contentlog)
+	if (!(opts->contentlog = realpath(optarg, NULL))) {
+		fprintf(stderr, "Failed to realpath '%s': %s (%i)\n",
+		              optarg, strerror(errno), errno);
 		oom_die(argv0);
+	}
 	opts->contentlog_isdir = 0;
 	opts->contentlog_isspec = 0;
 #ifdef DEBUG_OPTS
@@ -1123,9 +1127,11 @@ opts_set_masterkeylog(opts_t *opts, const char *argv0, const char *optarg)
 {
 	if (opts->masterkeylog)
 		free(opts->masterkeylog);
-	opts->masterkeylog = strdup(optarg);
-	if (!opts->masterkeylog)
+	if (!(opts->masterkeylog = realpath(optarg, NULL))) {
+		fprintf(stderr, "Failed to realpath '%s': %s (%i)\n",
+		              optarg, strerror(errno), errno);
 		oom_die(argv0);
+	}
 #ifdef DEBUG_OPTS
 	log_dbg_printf("MasterKeyLog: %s\n", opts->masterkeylog);
 #endif /* DEBUG_OPTS */
@@ -1136,9 +1142,11 @@ opts_set_pcaplog(opts_t *opts, const char *argv0, const char *optarg)
 {
 	if (opts->pcaplog)
 		free(opts->pcaplog);
-	opts->pcaplog = strdup(optarg);
-	if (!opts->pcaplog)
+	if (!(opts->pcaplog = realpath(optarg, NULL))) {
+		fprintf(stderr, "Failed to realpath '%s': %s (%i)\n",
+		              optarg, strerror(errno), errno);
 		oom_die(argv0);
+	}
 	opts->pcaplog_isdir = 0;
 	opts->pcaplog_isspec = 0;
 #ifdef DEBUG_OPTS


### PR DESCRIPTION
Otherwise the checks in `privsep_server_openfile_verify()` fail, preventing reopen upon USR1. This patch seems to be the simplest solution to me.