### PR TITLE
Deliberate access after free tests and LibreSSL 2.8.2

### DIFF
--- a/cachefkcrt.t.c
+++ b/cachefkcrt.t.c
@@ -117,7 +117,10 @@ START_TEST(cache_fkcrt_04)
 #ifndef LIBRESSL_VERSION_NUMBER
 	/* deliberate access of free'd X509* */
 	fail_unless(c1->references == 0, "refcount != 0");
-#endif /* !LIBRESSL_VERSION_NUMBER */
+#else /* LIBRESSL_VERSION_NUMBER */
+	fprintf(stderr, "deliberate access after free test in cache_fkcrt_04 "
+			"omitted because LibreSSL fails with refcount != 0\n");
+#endif /* LIBRESSL_VERSION_NUMBER */
 	fail_unless(cachemgr_preinit() != -1, "reinit");
 }
 END_TEST

--- a/cachefkcrt.t.c
+++ b/cachefkcrt.t.c
@@ -114,8 +114,10 @@ START_TEST(cache_fkcrt_04)
 	cachemgr_fini();
 	fail_unless(c1->references == 1, "refcount != 1");
 	X509_free(c2);
+#ifndef LIBRESSL_VERSION_NUMBER
 	/* deliberate access of free'd X509* */
 	fail_unless(c1->references == 0, "refcount != 0");
+#endif /* !LIBRESSL_VERSION_NUMBER */
 	fail_unless(cachemgr_preinit() != -1, "reinit");
 }
 END_TEST

--- a/cachetgcrt.t.c
+++ b/cachetgcrt.t.c
@@ -114,7 +114,10 @@ START_TEST(cache_tgcrt_04)
 #ifndef LIBRESSL_VERSION_NUMBER
 	/* deliberate access of free'd cert_t* */
 	fail_unless(c1->references == 0, "refcount != 0");
-#endif /* !LIBRESSL_VERSION_NUMBER */
+#else /* LIBRESSL_VERSION_NUMBER */
+	fprintf(stderr, "deliberate access after free test in cache_tgcrt_04 "
+			"omitted because LibreSSL fails with refcount != 0\n");
+#endif /* LIBRESSL_VERSION_NUMBER */
 	fail_unless(cachemgr_preinit() != -1, "reinit");
 }
 END_TEST

--- a/cachetgcrt.t.c
+++ b/cachetgcrt.t.c
@@ -111,8 +111,10 @@ START_TEST(cache_tgcrt_04)
 	cachemgr_fini();
 	fail_unless(c1->references == 1, "refcount != 1");
 	cert_free(c2);
+#ifndef LIBRESSL_VERSION_NUMBER
 	/* deliberate access of free'd cert_t* */
 	fail_unless(c1->references == 0, "refcount != 0");
+#endif /* !LIBRESSL_VERSION_NUMBER */
 	fail_unless(cachemgr_preinit() != -1, "reinit");
 }
 END_TEST

--- a/cert.t.c
+++ b/cert.t.c
@@ -62,8 +62,10 @@ START_TEST(cert_refcount_inc_01)
 	cert_free(c);
 	fail_unless(c->references == 1, "refcount mismatch");
 	cert_free(c);
+#ifndef LIBRESSL_VERSION_NUMBER
 	/* deliberate access after last free() */
 	fail_unless(c->references == 0, "refcount mismatch");
+#endif /* !LIBRESSL_VERSION_NUMBER */
 }
 END_TEST
 

--- a/cert.t.c
+++ b/cert.t.c
@@ -65,7 +65,11 @@ START_TEST(cert_refcount_inc_01)
 #ifndef LIBRESSL_VERSION_NUMBER
 	/* deliberate access after last free() */
 	fail_unless(c->references == 0, "refcount mismatch");
-#endif /* !LIBRESSL_VERSION_NUMBER */
+#else /* LIBRESSL_VERSION_NUMBER */
+	fprintf(stderr, "deliberate access after free test in "
+			"cert_refcount_inc_01 omitted because LibreSSL fails with refcount "
+			"mismatch\n");
+#endif /* LIBRESSL_VERSION_NUMBER */
 }
 END_TEST
 

--- a/extra/pki/GNUmakefile
+++ b/extra/pki/GNUmakefile
@@ -122,7 +122,7 @@ session.pem: server.pem
 	test -r $@
 
 clean:
-	rm -rf rsa.* dsa.* ec.* dh*.param targets *.srl session.pem server.*
+	rm -rf rsa.* dsa.* ec.* dh*.param targets *.srl server.*
 
 .PHONY: all clean rsa dsa ec dh session targets
 

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -316,7 +316,7 @@ static int pxy_ossl_servername_cb(SSL *ssl, int *al, void *arg);
 #endif /* !OPENSSL_NO_TLSEXT */
 static int pxy_ossl_sessnew_cb(SSL *, SSL_SESSION *);
 static void pxy_ossl_sessremove_cb(SSL_CTX *, SSL_SESSION *);
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20800000L)
 static SSL_SESSION * pxy_ossl_sessget_cb(SSL *, unsigned char *, int, int *);
 #else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 static SSL_SESSION * pxy_ossl_sessget_cb(SSL *, const unsigned char *, int,
@@ -630,7 +630,7 @@ pxy_ossl_sessremove_cb(UNUSED SSL_CTX *sslctx, SSL_SESSION *sess)
  * Called by OpenSSL when a src SSL session is requested by the client.
  */
 static SSL_SESSION *
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20800000L)
 pxy_ossl_sessget_cb(UNUSED SSL *ssl, unsigned char *id, int idlen,
                     int *copy)
 #else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */


### PR DESCRIPTION
Shall we disable these tests or keep them to detect if/when a future LibreSSL version supports them? (These tests fail with the latest LibreSSL 2.8.2 on OpenBSD 6.4 too.)

Before:
```
97%: Checks: 140, Failures: 3, Errors: 0
cert.t.c:66:F:cert_refcount_inc:cert_refcount_inc_01:0: refcount mismatch
cachefkcrt.t.c:118:F:cache_fkcrt:cache_fkcrt_04:0: refcount != 0
cachetgcrt.t.c:115:F:cache_tgcrt:cache_tgcrt_04:0: refcount != 0
```
After:
```
100%: Checks: 140, Failures: 0, Errors: 0
```
Also, the second commit fixes a warning on OpenBSD 6.4. Shall we fix it now or later?