### PR TITLE
Improve exit status

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 ### SSLsplit develop
 
+-   Propagate the exit status of the privsep child process to the parent
+    process and use 128+signal convention (issue #252).
 -   No longer create /var/log/sslsplit and /var/run/sslsplit directories as
     part of `make install` (issue #251).
 -   Minor bugfixes and improvements.
@@ -82,9 +84,9 @@ This release includes work sponsored by HackerOne.
 -   Fix data processing when EOF is received before all incoming data has been
     processed.
 -   Fix multiple signal handling issues in the privilege separation parent
-    which led to the parent process being killed ungracefully (SIGTERM) or
-    being stuck in wait() while still having signals (SIGQUIT etc) queued up
-    for forwarding to the child process (issue #137).
+    which led to the parent process being killed ungracefully or being stuck
+    in wait() while still having signals queued up for forwarding to the child
+    process (issue #137).
 -   No longer assume an out of memory condition when a certificate contains
     neither a CN nor a subjectAltName extension.
 -   Fix parallel make build (-j) for the test target (issue #140).

--- a/log.c
+++ b/log.c
@@ -63,7 +63,7 @@ void
 log_exceptcb(void)
 {
 	if (proxy_ctx) {
-		proxy_loopbreak(proxy_ctx);
+		proxy_loopbreak(proxy_ctx, -1);
 		proxy_ctx = NULL;
 	}
 }

--- a/main.c
+++ b/main.c
@@ -870,9 +870,21 @@ main(int argc, char *argv[])
 		log_err_printf("Failed to init NAT state table lookup.\n");
 		goto out_nat_failed;
 	}
-	rv = EXIT_SUCCESS;
 
-	proxy_run(proxy);
+	int proxy_rv = proxy_run(proxy);
+	if (proxy_rv == 0) {
+		rv = EXIT_SUCCESS;
+	} else if (proxy_rv > 0) {
+		/*
+		 * We terminated because of receving a signal.  For our normal
+		 * termination signals as documented in the man page, we want
+		 * to return with EXIT_SUCCESS.  For other signals, which
+		 * should be considered abnormal terminations, we want to
+		 * return an exit status of 128 + signal number.
+		 */
+		if (proxy_rv != SIGTERM && proxy_rv != SIGINT)
+			rv = 128 + proxy_rv;
+	}
 	proxy_free(proxy);
 	nat_fini();
 out_nat_failed:

--- a/main.c
+++ b/main.c
@@ -882,8 +882,11 @@ main(int argc, char *argv[])
 		 * should be considered abnormal terminations, we want to
 		 * return an exit status of 128 + signal number.
 		 */
-		if (proxy_rv != SIGTERM && proxy_rv != SIGINT)
+		if (proxy_rv == SIGTERM || proxy_rv == SIGINT) {
+			rv = EXIT_SUCCESS;
+		} else {
 			rv = 128 + proxy_rv;
+		}
 	}
 	proxy_free(proxy);
 	nat_fini();

--- a/main.c
+++ b/main.c
@@ -819,7 +819,7 @@ main(int argc, char *argv[])
 	 * remaining slots are passed down to log subsystem. */
 	int clisock[6];
 	if (privsep_fork(opts, clisock,
-	                 sizeof(clisock)/sizeof(clisock[0])) != 0) {
+	                 sizeof(clisock)/sizeof(clisock[0]), &rv) != 0) {
 		/* parent has exited the monitor loop after waiting for child,
 		 * or an error occurred */
 		if (opts->pidfile) {

--- a/main.c
+++ b/main.c
@@ -876,7 +876,7 @@ main(int argc, char *argv[])
 		rv = EXIT_SUCCESS;
 	} else if (proxy_rv > 0) {
 		/*
-		 * We terminated because of receving a signal.  For our normal
+		 * We terminated because of receiving a signal.  For our normal
 		 * termination signals as documented in the man page, we want
 		 * to return with EXIT_SUCCESS.  For other signals, which
 		 * should be considered abnormal terminations, we want to

--- a/privsep.h
+++ b/privsep.h
@@ -32,7 +32,7 @@
 #include "attrib.h"
 #include "opts.h"
 
-int privsep_fork(opts_t *, int[], size_t);
+int privsep_fork(opts_t *, int[], size_t, int *);
 
 int privsep_client_openfile(int, const char *, int);
 int privsep_client_opensock(int, const proxyspec_t *spec);

--- a/proxy.c
+++ b/proxy.c
@@ -393,7 +393,8 @@ proxy_run(proxy_ctx_t *ctx)
 	}
 	event_base_dispatch(ctx->evbase);
 	if (OPTS_DEBUG(ctx->opts)) {
-		log_dbg_printf("Main event loop stopped.\n");
+		log_dbg_printf("Main event loop stopped (reason=%i).\n",
+		               ctx->loopbreak_reason);
 	}
 	return ctx->loopbreak_reason;
 }

--- a/proxy.c
+++ b/proxy.c
@@ -66,6 +66,7 @@ struct proxy_ctx {
 	struct event *gcev;
 	struct proxy_listener_ctx *lctx;
 	opts_t *opts;
+	int loopbreak_reason;
 };
 
 
@@ -210,7 +211,7 @@ proxy_signal_cb(evutil_socket_t fd, UNUSED short what, void *arg)
 	case SIGQUIT:
 	case SIGINT:
 	case SIGHUP:
-		proxy_loopbreak(ctx);
+		proxy_loopbreak(ctx, fd);
 		break;
 	case SIGUSR1:
 		if (log_reopen() == -1) {
@@ -368,10 +369,11 @@ leave0:
 }
 
 /*
- * Run the event loop.  Returns when the event loop is cancelled by a signal
- * or on failure.
+ * Run the event loop.
+ * Returns 0 on non-signal termination, signal number when the event loop was
+ * cancelled by a signal, or -1 on failure.
  */
-void
+int
 proxy_run(proxy_ctx_t *ctx)
 {
 	if (ctx->opts->detach) {
@@ -384,7 +386,7 @@ proxy_run(proxy_ctx_t *ctx)
 #endif /* PURIFY */
 	if (pxy_thrmgr_run(ctx->thrmgr) == -1) {
 		log_err_printf("Failed to start thread manager\n");
-		return;
+		return -1;
 	}
 	if (OPTS_DEBUG(ctx->opts)) {
 		log_dbg_printf("Starting main event loop.\n");
@@ -393,14 +395,17 @@ proxy_run(proxy_ctx_t *ctx)
 	if (OPTS_DEBUG(ctx->opts)) {
 		log_dbg_printf("Main event loop stopped.\n");
 	}
+	return ctx->loopbreak_reason;
 }
 
 /*
- * Break the loop of the proxy, causing the proxy_run to return.
+ * Break the loop of the proxy, causing the proxy_run to return, returning
+ * the reason given in reason (signal number, 0 for success, -1 for error).
  */
 void
-proxy_loopbreak(proxy_ctx_t *ctx)
+proxy_loopbreak(proxy_ctx_t *ctx, int reason)
 {
+	ctx->loopbreak_reason = reason;
 	event_base_loopbreak(ctx->evbase);
 }
 

--- a/proxy.h
+++ b/proxy.h
@@ -35,8 +35,8 @@
 typedef struct proxy_ctx proxy_ctx_t;
 
 proxy_ctx_t * proxy_new(opts_t *, int) NONNULL(1) MALLOC;
-void proxy_run(proxy_ctx_t *) NONNULL(1);
-void proxy_loopbreak(proxy_ctx_t *) NONNULL(1);
+int proxy_run(proxy_ctx_t *) NONNULL(1);
+void proxy_loopbreak(proxy_ctx_t *, int) NONNULL(1);
 void proxy_free(proxy_ctx_t *) NONNULL(1);
 
 #endif /* !PROXY_H */

--- a/sslsplit.1.in
+++ b/sslsplit.1.in
@@ -484,20 +484,6 @@ no supported NAT engine or when running \fBsslsplit\fP on a different system
 than the NAT rules redirecting the actual connections.
 Note that when using \fB-j\fP with \fBsni\fP, you may need to prepare
 \fIjaildir\fP to make name resolution work from within the chroot directory.
-.SH SIGNALS
-A running \fBsslsplit\fP accepts SIGINT and SIGTERM for a clean shutdown and
-SIGUSR1 to re-open the single-file log files (such as \fB-l\fP, \fB-L\fP and
-\fB-X\fP).  The canonical way to rotate or post-process logs is to rename the
-active log file, send SIGUSR1 to the PID in the PID file given by \fB-p\fP,
-give SSLsplit some time to flush buffers after closing the old file, and then
-post-process the renamed log file.
-Per-connection log files (such as \fB-S\fP and \fB-F\fP) are not re-opened
-because their filename is specific to the connection.
-.SH "EXIT STATUS"
-The \fBsslsplit\fP process will exit with 0 on regular shutdown
-(SIGINT, SIGTERM), and 128 + signal number on controlled shutdown based on
-receiving a different signal such as SIGHUP.  Exit status in the range 1..127
-indicates error conditions.
 .SH "LOG SPECIFICATIONS"
 Log specifications are composed of zero or more printf-style directives;
 ordinary characters are included directly in the output path.
@@ -694,6 +680,20 @@ Fully supported, including IPv6.
 Note that return path filtering (rp_filter) also needs to be disabled on
 interfaces which handle TPROXY redirected traffic.
 .RE
+.SH SIGNALS
+A running \fBsslsplit\fP accepts SIGINT and SIGTERM for a clean shutdown and
+SIGUSR1 to re-open the single-file log files (such as \fB-l\fP, \fB-L\fP and
+\fB-X\fP).  The canonical way to rotate or post-process logs is to rename the
+active log file, send SIGUSR1 to the PID in the PID file given by \fB-p\fP,
+give SSLsplit some time to flush buffers after closing the old file, and then
+post-process the renamed log file.
+Per-connection log files (such as \fB-S\fP and \fB-F\fP) are not re-opened
+because their filename is specific to the connection.
+.SH "EXIT STATUS"
+The \fBsslsplit\fP process will exit with 0 on regular shutdown
+(SIGINT, SIGTERM), and 128 + signal number on controlled shutdown based on
+receiving a different signal such as SIGHUP.  Exit status in the range 1..127
+indicates error conditions.
 .SH EXAMPLES
 Matching the above NAT engine configuration samples, intercept HTTP and HTTPS
 over IPv4 and IPv6 using forged certificates with CA private key \fBca.key\fP

--- a/sslsplit.1.in
+++ b/sslsplit.1.in
@@ -485,7 +485,7 @@ than the NAT rules redirecting the actual connections.
 Note that when using \fB-j\fP with \fBsni\fP, you may need to prepare
 \fIjaildir\fP to make name resolution work from within the chroot directory.
 .SH SIGNALS
-A running \fBsslsplit\fP accepts SIGINT and SIGQUIT for a clean shutdown and
+A running \fBsslsplit\fP accepts SIGINT and SIGTERM for a clean shutdown and
 SIGUSR1 to re-open the single-file log files (such as \fB-l\fP, \fB-L\fP and
 \fB-X\fP).  The canonical way to rotate or post-process logs is to rename the
 active log file, send SIGUSR1 to the PID in the PID file given by \fB-p\fP,
@@ -493,6 +493,11 @@ give SSLsplit some time to flush buffers after closing the old file, and then
 post-process the renamed log file.
 Per-connection log files (such as \fB-S\fP and \fB-F\fP) are not re-opened
 because their filename is specific to the connection.
+.SH "EXIT STATUS"
+The \fBsslsplit\fP process will exit with 0 on regular shutdown
+(SIGINT, SIGTERM), and 128 + signal number on controlled shutdown based on
+receiving a different signal such as SIGHUP.  Exit status in the range 1..127
+indicates error conditions.
 .SH "LOG SPECIFICATIONS"
 Log specifications are composed of zero or more printf-style directives;
 ordinary characters are included directly in the output path.


### PR DESCRIPTION
This pull request is meant to address #252 in the following ways:

- sslsplit will now propagate the privsep child process' exit status to the parent process
- exit status will now be 0 for regular shutdown via SIGINT or SIGTERM
- exit status will now be 128 + signal number if we shut down after catching a different signal that we consider a non-regular shutdown (currently only SIGHUP and SIGQUIT)
- exit status 1..127 are used for error conditions such as config errors or runtime errors; currently exit status 1 is used for all errors but we could change that in the future to e.g. differentiate fatal config errors from runtime errors

Signals that are non-fatal, such as SIGUSR1, will not lead to a shutdown. Some signals not handled by sslsplit, such as SIGKILL or SIGSEGV, will lead to a termination by the kernel, meaning that the process interested in the exit status will use wait(2) to acquire the signal. In the special case of sslsplit running directly from a shell, most shells will translate the signal number to an exit status using the same scheme of 128 + signal number.

All of this is only relevant when not running sslsplit as a daemon.