### PR TITLE
Default leaf certificate option and option name cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 ### SSLsplit develop
 
+-   Add -A option for specifying a default leaf certificate instead of
+    generating it on the fly (issue #139).
+-   Rename the following config file options for clarity and consistency:
+    -   LeafCerts to LeafKey
+    -   TargetCertDir to LeafCertDir
+    -   CRL to LeafCRLURL
+    The old syntax is still accepted for backwards compatibility.
 -   Increase the default RSA leaf key size to 2048 bits and force an OpenSSL
     security level of 0 in order to maximize interoperability in the default
     configuration.  OpenSSL with a security level of 2 or higher was rejecting

--- a/sslsplit.1.in
+++ b/sslsplit.1.in
@@ -116,6 +116,16 @@ reconfiguration or route injection, /etc/hosts modification and so on.
 .B \-a \fIpemfile\fP
 Use client certificate from \fIpemfile\fP when destination server requests a
 client certificate.
+.B \-A \fIpemfile\fP
+Use private key, certificate and certificate chain from PEM file \fIpemfile\fP
+as leaf certificate instead of generating a leaf certificate on the fly.
+The PEM file must contain a single private key, a single certificate and
+optionally intermediate and root CA certificates to use as certificate chain.
+When using \fB-t\fP, SSLsplit will first attempt to use a matching certificate
+loaded from \fIcertdir\fP.
+If \fB-t\fP is also used and a connection matches any certificate in the
+directory specified with the \fB-t\fP option, that matching certificate is used
+instead, taking precedence over the certificate specified with \fB-A\fP.
 .TP
 .B \-b \fIpemfile\fP
 Use client private key from \fIpemfile\fP when destination server requests a
@@ -334,7 +344,10 @@ A single PEM file must contain a single private key, a single certificate and
 optionally intermediate and root CA certificates to use as certificate chain.
 When using \fB-t\fP, SSLsplit will first attempt to use a matching certificate
 loaded from \fIcertdir\fP.
-If \fB-c\fP and \fB-k\fP are also given, certificates will be forged
+If \fB-A\fP is also given, when there is no match in \fIcertdir\fP, the default
+key, certificate and certificate chain from the PEM file specified with the
+\fB-A\fP option is used instead.
+Otherwise, if \fB-c\fP and \fB-k\fP are also given, certificates will be forged
 on-the-fly for sites matching none of the common names in the certificates
 loaded from \fIcertdir\fP.
 Otherwise, connections matching no certificate will be dropped, or if

--- a/sslsplit.conf.5.in
+++ b/sslsplit.conf.5.in
@@ -63,16 +63,19 @@ Use key from pemfile when destination requests client certs. Equivalent to -b co
 \fBCAChain STRING\fR
 Use CA chain from pemfile (intermediate and root CA certs). Equivalent to -C command line option.
 .TP
-\fBLeafCerts STRING\fR
-Use key from pemfile for leaf certs. Equivalent to -K command line option.
+\fBLeafKey STRING\fR
+Use key from pemfile for generating leaf certs. Equivalent to -K command line option.
 .br
 Default: generate
 .TP
-\fBCRL STRING\fR
-Use URL as CRL distribution point for all forged certs. Equivalent to -q command line option.
+\fBLeafCRLURL STRING\fR
+Use URL as CRL distribution point for all forged leaf certs. Equivalent to -q command line option.
 .TP
-\fBTargetCertDir STRING\fR
+\fBLeafCertDir STRING\fR
 Use cert+chain+key PEM files from certdir to target all sites matching the common names (non-matching: generate if CA). Equivalent to -t command line option.
+.TP
+\fBDefaultLeafCert STRING\fR
+Use cert+chain+key from PEM file for leaf certificates if there is no match in \fBLeafCertDir\fR. Equivalent to -A command line option.
 .TP
 \fBWriteGenCertsDir STRING\fR
 Write leaf key and only generated certificates to gendir. Equivalent to -w command line option.

--- a/sslsplit.conf.in
+++ b/sslsplit.conf.in
@@ -23,19 +23,23 @@ CAKey /usr/local/etc/sslsplit/ca.key
 # Equivalent to -C command line option.
 #CAChain /usr/local/etc/sslsplit/chain.crt
 
-# Use key from pemfile for leaf certs.
+# Use key from pemfile for generated leaf certs.
 # Equivalent to -K command line option.
 # (default: generate)
-#LeafCerts /usr/local/etc/sslsplit/leaf.key
+#LeafKey /usr/local/etc/sslsplit/leaf.key
 
 # Use URL as CRL distribution point for all forged certs.
 # Equivalent to -q command line option.
-#CRL http://example.com/example.crl
+#LeafCRLURL http://example.com/example.crl
 
 # Use cert+chain+key PEM files from certdir to target all sites matching the
 # common names (non-matching: generate if CA).
 # Equivalent to -t command line option.
-#TargetCertDir /usr/local/etc/sslsplit/target
+#LeafCertDir /usr/local/etc/sslsplit/leaf.d
+
+# Use cert+chain+key from PEM file instead of generating leaf keys on the fly.
+# Equivalent to -A command line option.
+#DefaultLeafCert /usr/local/etc/sslsplit/leaf.pem
 
 # Write leaf key and only generated certificates to gendir.
 # Equivalent to -w command line option.


### PR DESCRIPTION
As per #139, add `-A` command line option and `DefaultLeafCert` config file option to use a default leaf certificate in lieu of generating one on the fly. If `-t` is also used and a certificate matches the connection, `-t` takes precedence.

To add some clarity and consistency to our options, renamed some config file options:
-   `LeafCerts` to `LeafKey`
-   `TargetCertDir` to `LeafCertDir`
-   `CRL` to `LeafCRLURL`

The old options are still recognized for backwards compatibility.