### PR TITLE
Unify test and mkdir target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -523,7 +523,7 @@ $(TARGET).conf.5: $(TARGET).conf.5.in $(MKFS) FORCE
 install: $(TARGET) $(TARGET).conf $(TARGET).1 $(TARGET).conf.5
 	test -d $(DESTDIR)$(PREFIX)/bin || $(MKDIR) -p $(DESTDIR)$(PREFIX)/bin
 	test -d $(DESTDIR)$(PREFIX)/$(TARGET) || \
-		$(MKDIR) -p $(DESTDIR)$(PREFIX)/sslsplit
+		$(MKDIR) -p $(DESTDIR)$(PREFIX)/$(TARGET)
 	test -d $(DESTDIR)$(PREFIX)/$(MANDIR)/man1 || \
 		$(MKDIR) -p $(DESTDIR)$(PREFIX)/$(MANDIR)/man1
 	test -d $(DESTDIR)$(PREFIX)/$(MANDIR)/man5 || \


### PR DESCRIPTION
This change prefers `TARGET` variable over the hardcoded name.

However, I am not sure why we need to create empty `/usr/local/sslsplit` directory in the filesystem. I believe that we should remove lines
```make
	test -d $(DESTDIR)$(PREFIX)/$(TARGET) || \
			$(MKDIR) -p $(DESTDIR)$(PREFIX)/sslsplit
```
with similar reason like in #251, distributions should create it in theirs preferred location.