### PR TITLE
mirror: support special 'none' target value for -T

### DIFF
--- a/logpkt.c
+++ b/logpkt.c
@@ -740,6 +740,17 @@ logpkt_ether_lookup(libnet_t *libnet,
 	int count = 50;
 	logpkt_recv_arp_reply_ctx_t ctx;
 
+	/* handle case of just spitting packets out, not caring about a dest */
+	if (strcmp(dst_ip_s, "none") == 0) {
+		uint8_t src[ETHER_ADDR_LEN] = {
+			0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+		uint8_t dst[ETHER_ADDR_LEN] = {
+			0x2, 0x2, 0x2, 0x2, 0x2, 0x2};
+		memcpy(src_ether, &src, ETHER_ADDR_LEN);
+		memcpy(dst_ether, &dst, ETHER_ADDR_LEN);
+		return 0;
+	}
+
 	if (sys_get_af(dst_ip_s) != AF_INET) {
 		log_err_printf("Mirroring target must be an IPv4 address.\n");
 		return -1;

--- a/main.c
+++ b/main.c
@@ -226,6 +226,7 @@ main_usage(void)
 #ifndef WITHOUT_MIRROR
 "  -I if       mirror packets to interface\n"
 "  -T addr     mirror packets to target address (used with -I)\n"
+"              Use \"none\" to blindly send packets out of <if>.\n"
 #define OPT_I "I:"
 #define OPT_T "T:"
 #else /* WITHOUT_MIRROR */


### PR DESCRIPTION
Support "none" as a target value, indicating the target is irrelevant.

The use case is an IDS sensor listening on a dummy interface for the
packets sslsplit produces. The IDS will listen in promisc mode, so the
target is irrelevant.