### PR TITLE
mirror: allow mirroring without explict target

### DIFF
--- a/logpkt.c
+++ b/logpkt.c
@@ -740,6 +740,17 @@ logpkt_ether_lookup(libnet_t *libnet,
 	int count = 50;
 	logpkt_recv_arp_reply_ctx_t ctx;
 
+	/* handle case of just spitting packets out, not caring about a dest */
+	if (!dst_ip_s) {
+		uint8_t src[ETHER_ADDR_LEN] = {
+			0x1, 0x1, 0x1, 0x1, 0x1, 0x1};
+		uint8_t dst[ETHER_ADDR_LEN] = {
+			0x2, 0x2, 0x2, 0x2, 0x2, 0x2};
+		memcpy(src_ether, &src, ETHER_ADDR_LEN);
+		memcpy(dst_ether, &dst, ETHER_ADDR_LEN);
+		return 0;
+	}
+
 	if (sys_get_af(dst_ip_s) != AF_INET) {
 		log_err_printf("Mirroring target must be an IPv4 address.\n");
 		return -1;

--- a/main.c
+++ b/main.c
@@ -225,7 +225,7 @@ main_usage(void)
 "              see option -F for pathspec format\n"
 #ifndef WITHOUT_MIRROR
 "  -I if       mirror packets to interface\n"
-"  -T addr     mirror packets to target address (used with -I)\n"
+"  -T addr     mirror packets to target address (optionally used with -I)\n"
 #define OPT_I "I:"
 #define OPT_T "T:"
 #else /* WITHOUT_MIRROR */
@@ -512,10 +512,6 @@ main(int argc, char *argv[])
 #ifndef WITHOUT_MIRROR
 	if (opts->mirrortarget && !opts->mirrorif) {
 		fprintf(stderr, "%s: -T depends on -I.\n", argv0);
-		exit(EXIT_FAILURE);
-	}
-	if (opts->mirrorif && !opts->mirrortarget) {
-		fprintf(stderr, "%s: -I depends on -T.\n", argv0);
 		exit(EXIT_FAILURE);
 	}
 #endif /* !WITHOUT_MIRROR */

--- a/sslsplit.1.in
+++ b/sslsplit.1.in
@@ -204,7 +204,8 @@ not been implemented yet.
 .B \-I \fIif\fP
 Mirror connection content as emulated packets to interface \fIif\fP with
 destination address given by \fB-T\fP.  This option is not available if
-SSLsplit was built without mirroring support.
+SSLsplit was built without mirroring support. If \fB-T\fP is omitted, the
+packets are blindly pushed to \fIif\fP.
 .TP
 .B \-j \fIjaildir\fP
 Change the root directory to \fIjaildir\fP using chroot(2) after opening files.

--- a/sslsplit.conf.in
+++ b/sslsplit.conf.in
@@ -159,7 +159,8 @@ PidFile /var/run/sslsplit.pid
 #MirrorIf lo
 
 # Mirror packets to target address (used with MirrorIf).
-# Equivalent to -T command line option.
+# Equivalent to -T command line option. Leave commented if the target is
+# irrelevant (e.g. mirror to dummy device)
 #MirrorTarget 192.0.2.1
 
 # Log master keys to logfile in SSLKEYLOGFILE format.


### PR DESCRIPTION
Allow omitting the -T option, indicating the target is irrelevant.

The use case is an IDS sensor listening on a dummy interface for the
packets sslsplit produces. The IDS will listen in promisc mode, so the
target is irrelevant.

How I've tested this:

```
ip link add decrypted type dummy
ip link set decrypted up
<iptables rules to redirect>
sslsplit -j /tmp/sslsplit/  -S logdir/ -k ca.key -c ca.crt -I decrypted https 0.0.0.0 8443
tcpdump -i decrypted
```
Replaces #282. If code looks good I'll do the doc side next.