### PR TITLE
Implement partial support for TLSv1.3

### DIFF
--- a/opts.c
+++ b/opts.c
@@ -237,7 +237,7 @@ opts_has_dns_spec(opts_t *opts)
 void
 opts_proto_dbg_dump(opts_t *opts)
 {
-	log_dbg_printf("SSL/TLS protocol: %s%s%s%s%s%s\n",
+	log_dbg_printf("SSL/TLS protocol: %s%s%s%s%s%s%s\n",
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
 #ifdef HAVE_SSLV2
 	               (opts->sslmethod == SSLv2_method) ? "ssl2" :

--- a/opts.c
+++ b/opts.c
@@ -267,6 +267,9 @@ opts_proto_dbg_dump(opts_t *opts)
 #ifdef HAVE_TLSV12
 	               (opts->sslversion == TLS1_2_VERSION) ? "tls12" :
 #endif /* HAVE_TLSV12 */
+#ifdef HAVE_TLSV13
+                       (opts->sslversion == TLS1_3_VERSION) ? "tls13" :
+#endif /* HAVE_TLSV13 */
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 	               "negotiate",
 #ifdef HAVE_SSLV2
@@ -288,6 +291,10 @@ opts_proto_dbg_dump(opts_t *opts)
 #ifdef HAVE_TLSV12
 	               opts->no_tls12 ? " -tls12" :
 #endif /* HAVE_TLSV12 */
+                       "",
+#ifdef HAVE_TLSV13
+                       opts->no_tls13 ? " -tls13" :
+#endif /* HAVE_TLSV13 */
 	               "");
 }
 
@@ -912,6 +919,11 @@ opts_force_proto(opts_t *opts, const char *argv0, const char *optarg)
 		opts->sslversion = TLS1_2_VERSION;
 	} else
 #endif /* HAVE_TLSV12 */
+#ifdef HAVE_TLSV13
+        if (!strcmp(optarg, "tls13")) {
+                opts->sslversion = TLS1_3_VERSION;
+        } else
+#endif /* HAVE_TLSV13 */
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 	{
 		fprintf(stderr, "%s: Unsupported SSL/TLS protocol '%s'\n",
@@ -955,6 +967,11 @@ opts_disable_proto(opts_t *opts, const char *argv0, const char *optarg)
 		opts->no_tls12 = 1;
 	} else
 #endif /* HAVE_TLSV12 */
+#ifdef HAVE_TLSV13
+        if (!strcmp(optarg, "tls13")) {
+                opts->no_tls13 = 1;
+        } else
+#endif /* HAVE_TLSV13 */
 	{
 		fprintf(stderr, "%s: Unsupported SSL/TLS protocol '%s'\n",
 		                argv0, optarg);

--- a/opts.h
+++ b/opts.h
@@ -73,6 +73,9 @@ typedef struct opts {
 #ifdef HAVE_TLSV12
 	unsigned int no_tls12 : 1;
 #endif /* HAVE_TLSV12 */
+#ifdef HAVE_TLSV13
+        unsigned int no_tls13 : 1;
+#endif /* HAVE_TLSV13 */
 	unsigned int passthrough : 1;
 	unsigned int deny_ocsp : 1;
 	unsigned int contentlog_isdir : 1;

--- a/ssl.c
+++ b/ssl.c
@@ -1213,6 +1213,8 @@ ssl_x509chain_load(X509 **crt, STACK_OF(X509) **chain, const char *filename)
 	if (!tmpctx)
 		goto leave1;
 
+	SSL_CTX_set_security_level(tmpctx, 0);
+
 	rv = SSL_CTX_use_certificate_chain_file(tmpctx, filename);
 	if (rv != 1)
 		goto leave2;
@@ -1303,6 +1305,7 @@ ssl_x509_load(const char *filename)
 	tmpctx = SSL_CTX_new(SSLv23_server_method());
 	if (!tmpctx)
 		goto leave1;
+	SSL_CTX_set_security_level(tmpctx, 0);
 	rv = SSL_CTX_use_certificate_file(tmpctx, filename, SSL_FILETYPE_PEM);
 	if (rv != 1)
 		goto leave2;

--- a/ssl.c
+++ b/ssl.c
@@ -1213,8 +1213,6 @@ ssl_x509chain_load(X509 **crt, STACK_OF(X509) **chain, const char *filename)
 	if (!tmpctx)
 		goto leave1;
 
-	SSL_CTX_set_security_level(tmpctx, 0);
-
 	rv = SSL_CTX_use_certificate_chain_file(tmpctx, filename);
 	if (rv != 1)
 		goto leave2;
@@ -1305,7 +1303,6 @@ ssl_x509_load(const char *filename)
 	tmpctx = SSL_CTX_new(SSLv23_server_method());
 	if (!tmpctx)
 		goto leave1;
-	SSL_CTX_set_security_level(tmpctx, 0);
 	rv = SSL_CTX_use_certificate_file(tmpctx, filename, SSL_FILETYPE_PEM);
 	if (rv != 1)
 		goto leave2;

--- a/ssl.h
+++ b/ssl.h
@@ -166,6 +166,9 @@ X509 * ssl_ssl_cert_get(SSL *);
 #ifdef SSL_OP_NO_TLSv1_2
 #define HAVE_TLSV12
 #endif /* SSL_OP_NO_TLSv1_2 */
+#ifdef SSL_OP_NO_TLSv1_3
+#define HAVE_TLSV13
+#endif /* SSL_OP_NO_TLSv1_3 */
 
 #ifdef HAVE_SSLV2
 #define SSL2_S "ssl2 "
@@ -192,7 +195,12 @@ X509 * ssl_ssl_cert_get(SSL *);
 #else /* !HAVE_TLSV12 */
 #define TLS12_S ""
 #endif /* !HAVE_TLSV12 */
-#define SSL_PROTO_SUPPORT_S SSL2_S SSL3_S TLS10_S TLS11_S TLS12_S
+#ifdef HAVE_TLSV13
+#define TLS13_S "tls13 "
+#else /* !HAVE_TLSV13 */
+#define TLS13_S ""
+#endif /* !HAVE_TLSV13 */
+#define SSL_PROTO_SUPPORT_S SSL2_S SSL3_S TLS10_S TLS11_S TLS12_S TLS13_S
 
 void ssl_openssl_version(void);
 int ssl_init(void) WUNRES;


### PR DESCRIPTION
Some items from #220
- add to -r and -R config options to require/prohibit
- fallback to TLSv1.2 when source connection is missing SNI
  (it is required in TLSv1.3)