### PR TITLE
Lower openssl seclevel to 0 at config time

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -1213,6 +1213,10 @@ ssl_x509chain_load(X509 **crt, STACK_OF(X509) **chain, const char *filename)
 	if (!tmpctx)
 		goto leave1;
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+	SSL_CTX_set_security_level(tmpctx, 0);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+
 	rv = SSL_CTX_use_certificate_chain_file(tmpctx, filename);
 	if (rv != 1)
 		goto leave2;
@@ -1303,6 +1307,11 @@ ssl_x509_load(const char *filename)
 	tmpctx = SSL_CTX_new(SSLv23_server_method());
 	if (!tmpctx)
 		goto leave1;
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+        SSL_CTX_set_security_level(tmpctx, 0);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+
 	rv = SSL_CTX_use_certificate_file(tmpctx, filename, SSL_FILETYPE_PEM);
 	if (rv != 1)
 		goto leave2;
@@ -1338,6 +1347,11 @@ ssl_key_load(const char *filename)
 	tmpctx = SSL_CTX_new(SSLv23_server_method());
 	if (!tmpctx)
 		goto leave1;
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+        SSL_CTX_set_security_level(tmpctx, 0);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+
 	rv = SSL_CTX_use_PrivateKey_file(tmpctx, filename, SSL_FILETYPE_PEM);
 	if (rv != 1)
 		goto leave2;


### PR DESCRIPTION
Currently the openssl security level is set to 0 when making and
receiving proxied connections, but ca and client certificates
specified in config are pre-loaded using a temporary ssl context
that does not have the security level explicity reduced, resulting
in failure to load, for example 1024-bit RSA client certs

Fix by lowering the seclevel on all temp contexts as well