### PR TITLE
Add global site passthrough to ignore pinning

### DIFF
--- a/opts.c
+++ b/opts.c
@@ -68,7 +68,7 @@ opts_load_cert_chain_key(const char *filename)
 		return NULL;
 	}
 	if (X509_check_private_key(cert->crt, cert->key) != 1) {
-		log_err_printf("Cert doess not match key in PEM file "
+		log_err_printf("Cert does not match key in PEM file "
 		                "'%s':\n", filename);
 		ERR_print_errors_fp(stderr);
 		return NULL;

--- a/opts.c
+++ b/opts.c
@@ -1354,21 +1354,54 @@ opts_unset_allow_wrong_host(opts_t *opts)
 	opts->allow_wrong_host = 0;
 }
 
-static void
-opts_set_pass_site(opts_t *opts, const char *value)
+void
+opts_set_pass_site(opts_t *opts, char *value, int line_num)
 {
-	if (!opts->passthrough) {
-		fprintf(stderr, "PassSite requires Passthrough option\n");
+	// site [(clientaddr|(user|*) [description keyword])]
+	char *argv[sizeof(char *) * 3];
+	int argc = 0;
+	char *p, *last = NULL;
+
+	for ((p = strtok_r(value, " ", &last));
+		 p;
+		 (p = strtok_r(NULL, " ", &last))) {
+		if (argc < 3) {
+			argv[argc++] = p;
+		} else {
+			break;
+		}
+	}
+	if (!argc) {
+		fprintf(stderr, "PassSite requires at least one parameter on line %d\n", line_num);
 		exit(EXIT_FAILURE);
 	}
 	passsite_t *ps = malloc(sizeof(passsite_t));
-	ps->site = strdup(value);
+	memset(ps, 0, sizeof(passsite_t));
+	size_t len = strlen(argv[0]);
+	// Common names are separated by slashes
+	char s[len + 3];
+	memcpy(s + 1, argv[0], len);
+	s[0] = '/';
+	s[len + 1] = '/';
+	s[len + 2] = '\0';
+	ps->site = strdup(s);
+
+	if (argc > 1) {
+			ps->ip = strdup(argv[1]);
+	}
+	if (argc > 2) {
+		if (ps->ip) {
+			fprintf(stderr, "PassSite client ip cannot define keyword filter on line %d\n", line_num);
+			exit(EXIT_FAILURE);
+		}
+	}
 	ps->next = opts->passsites;
 	opts->passsites = ps;
 #ifdef DEBUG_OPTS
-	log_dbg_printf("PassSite: %s\n", value);
+	log_dbg_printf("PassSite: %s, %s\n", ps->site, STRORDASH(ps->ip));
 #endif /* DEBUG_OPTS */
 }
+
 
 static int
 check_value_yesno(const char *value, const char *name, int line_num)
@@ -1572,7 +1605,7 @@ set_option(opts_t *opts, const char *argv0,
 		               opts->allow_wrong_host);
 #endif /* DEBUG_OPTS */
 	} else if (!strncmp(name, "PassSite", 9)) {
-		opts_set_pass_site(opts, value);
+		opts_set_pass_site(opts, value, line_num);
 	} else {
 		fprintf(stderr, "Error in conf: Unknown option "
 		                "'%s' at line %d\n", name, line_num);

--- a/opts.h
+++ b/opts.h
@@ -54,6 +54,11 @@ typedef struct proxyspec {
 	struct proxyspec *next;
 } proxyspec_t;
 
+typedef struct passsite {
+	char *site;
+	struct passsite *next;
+} passsite_t;
+
 typedef struct opts {
 	unsigned int debug : 1;
 	unsigned int detach : 1;
@@ -125,6 +130,7 @@ typedef struct opts {
 	proxyspec_t *spec;
 	unsigned int verify_peer: 1;
 	unsigned int allow_wrong_host: 1;
+	struct passsite *passsites; 
 } opts_t;
 
 void NORET oom_die(const char *) NONNULL(1);

--- a/opts.h
+++ b/opts.h
@@ -54,8 +54,15 @@ typedef struct proxyspec {
 	struct proxyspec *next;
 } proxyspec_t;
 
+// typedef struct passsite {
+// 	char *site;
+// 	struct passsite *next;
+// } passsite_t;
+
 typedef struct passsite {
 	char *site;
+	// Filter definition fields
+	char *ip;
 	struct passsite *next;
 } passsite_t;
 


### PR DESCRIPTION
Hi, thanks for this wonderful project.
Following several recent issues, it seems that the current passthrough implementation cannot work with apps that implement pinning, since it only operates once the connection has already been initiated/spoofed.
The sister project sslproxy already implemented a per-domain whitelist that prevents spoofing for defined sites.
I've backported their code to sslsplit.

Note that I don't write C code and do not understand any of the details involved.
This patch compiles and works, and I've tried to retain the code, naming and formatting style.
But it should definitely be reviewed by someone who knows what they are doing (which you obviously are!) before merging.

By the way, if this is inconvenient or does not fit the project's scope, feel free to discard the PR.
Thanks & Regards!