### PR TITLE
Correct header-size calculation in IPv6 packet mirroring

### DIFF
--- a/logpkt.c
+++ b/logpkt.c
@@ -455,8 +455,7 @@ logpkt_mirror_build(libnet_t *libnet,
 	} else {
 		ptag = libnet_build_ipv6(0,             /* traffic class */
 		                         0,             /* flow label */
-		                         LIBNET_IPV6_H + LIBNET_TCP_H +
-		                         payloadlen,
+		                         LIBNET_TCP_H + payloadlen,
 		                         IPPROTO_TCP,
 		                         255,           /* hop limit */
 		                         *(struct libnet_in6_addr *)


### PR DESCRIPTION
I found this issue because my packet inspection system was able to correctly process decrypted IPv4 packets mirrored to a dummy interface, but was unable to process decrypted IPv6 ones.  When running tcpdump on the interface, it marked the packets as "truncated-ip6".

Wireshark complained about "IPv6 payload length exceeds framing length". Comparing different packets of different sizes, I measured that each packet had a Payload Length field 40 bytes larger than it should be, the size of the IPv6 header.

I found the explanation here:
https://www.opus1.com/ipv6/whatdoesapacketlooklike.html

> Payload Length - This 16-bit field is similar to the IPv4 Total Length
Field, except that with IPv6 the Payload Length field is the length of the data carried after the header, whereas with IPv4 the Total Length Field included the header.

Therefore for IPv6, the packet length we should pass to libnet is the size of the TCP header plus the size of the payload, but NOT including the size of the IPv6 header.  This patch fixed the problem for me and now my packet inspection system properly reads the packets, and Wireshark no longer complains about malformed packets :)