### PR TITLE
log.c: fix double free

### DIFF
--- a/log.c
+++ b/log.c
@@ -1454,10 +1454,8 @@ log_cert_submit(const char *fn, X509 *crt)
 	if (!(pem = ssl_x509_to_pem(crt)))
 		goto errout2;
 	if (!(lb = logbuf_new(pem, strlen(pem), NULL)))
-		goto errout3;
+		goto errout2;
 	return logger_submit(cert_log, fh, 0, lb);
-errout3:
-	free(pem);
 errout2:
 	free(fh);
 errout1:

--- a/logger.c
+++ b/logger.c
@@ -306,7 +306,6 @@ logger_printf(logger_t *logger, void *fh, unsigned long prepflags,
 
 	if (!(lb = logbuf_new(NULL, 0, NULL)))
 		return -1;
-	lb->fh = fh;
 	va_start(ap, fmt);
 	lb->sz = vasprintf((char**)&lb->buf, fmt, ap);
 	va_end(ap);
@@ -324,7 +323,6 @@ logger_write(logger_t *logger, void *fh, unsigned long prepflags,
 
 	if (!(lb = logbuf_new_copy(buf, sz, NULL)))
 		return -1;
-	lb->fh = fh;
 	return logger_submit(logger, fh, prepflags, lb);
 }
 int
@@ -335,7 +333,6 @@ logger_print(logger_t *logger, void *fh, unsigned long prepflags,
 
 	if (!(lb = logbuf_new_copy(s, strlen(s), NULL)))
 		return -1;
-	lb->fh = fh;
 	return logger_submit(logger, fh, prepflags, lb);
 }
 int
@@ -346,19 +343,13 @@ logger_write_freebuf(logger_t *logger, void *fh, unsigned long prepflags,
 
 	if (!(lb = logbuf_new(buf, sz, NULL)))
 		return -1;
-	lb->fh = fh;
 	return logger_submit(logger, fh, prepflags, lb);
 }
 int
 logger_print_freebuf(logger_t *logger, void *fh, unsigned long prepflags,
                      char *s)
 {
-	logbuf_t *lb;
-
-	if (!(lb = logbuf_new(s, strlen(s), NULL)))
-		return -1;
-	lb->fh = fh;
-	return logger_submit(logger, fh, prepflags, lb);
+	return logger_write_freebuf(logger, fh, prepflags, s, strlen(s));
 }
 
 /* vim: set noet ft=c: */

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -454,7 +454,6 @@ pxy_log_connect_nonhttp(pxy_conn_ctx_t *ctx)
 	}
 	if (ctx->opts->connectlog) {
 		if (log_connect_print_free(msg) == -1) {
-			free(msg);
 			log_err_printf("Warning: Connection logging failed\n");
 		}
 	} else {
@@ -567,7 +566,6 @@ pxy_log_connect_http(pxy_conn_ctx_t *ctx)
 	}
 	if (ctx->opts->connectlog) {
 		if (log_connect_print_free(msg) == -1) {
-			free(msg);
 			log_err_printf("Warning: Connection logging failed\n");
 		}
 	} else {


### PR DESCRIPTION
Bug found by Svace static analyzer:

  Pointer 'pem' is passed to a function free at log.c:1468 by calling function 'free'
  after the referenced memory was deallocated at logbuf.c:54 by passing as 1st parameter
  to function 'logbuf_new' at log.c:1464