### PR TITLE
pxyconn.c: fix double free of host and serv variables

### DIFF
--- a/sys.c
+++ b/sys.c
@@ -486,6 +486,7 @@ sys_sockaddr_str(struct sockaddr *addr, socklen_t addrlen,
 		log_err_printf("Cannot get nameinfo for socket address: %s\n",
 		               gai_strerror(rv));
 		free(*serv);
+		*serv = NULL;
 		return -1;
 	}
 	hostsz = strlen(tmphost) + 1; /* including terminator */
@@ -493,6 +494,7 @@ sys_sockaddr_str(struct sockaddr *addr, socklen_t addrlen,
 	if (!*host) {
 		log_err_printf("Cannot allocate memory\n");
 		free(*serv);
+		*serv = NULL;
 		return -1;
 	}
 	memcpy(*host, tmphost, hostsz);


### PR DESCRIPTION
    When -1 is returned from sys_sockaddr_str, pointers in *host
    and *serv are invalid and must not be used nor freed by the caller