### PR TITLE
fix clang-static-analysis warnings

### DIFF
--- a/cachedsess.c
+++ b/cachedsess.c
@@ -211,7 +211,8 @@ cachedsess_mkkey(const struct sockaddr *addr, UNUSED const socklen_t addrlen,
 		return NULL;
 	memcpy(db->buf, tmp.buf, tmp.sz);
 	memcpy(db->buf + tmp.sz, (char*)&port, sizeof(port));
-	memcpy(db->buf + tmp.sz + sizeof(port), sni, snilen);
+	if (sni)
+		memcpy(db->buf + tmp.sz + sizeof(port), sni, snilen);
 	return db;
 }
 

--- a/log.h
+++ b/log.h
@@ -94,7 +94,7 @@ int log_cert_submit(const char *, X509 *) NONNULL(1,2) WUNRES;
 
 int log_preinit(opts_t *) NONNULL(1) WUNRES;
 void log_preinit_undo(void);
-int log_init(opts_t *, proxy_ctx_t *, int[3]) NONNULL(1,2) WUNRES;
+int log_init(opts_t *, proxy_ctx_t *, int[5]) NONNULL(1,2) WUNRES;
 void log_fini(void);
 int log_reopen(void) WUNRES;
 void log_exceptcb(void);

--- a/pxyconn.c
+++ b/pxyconn.c
@@ -1819,13 +1819,13 @@ pxy_bev_readcb(struct bufferevent *bev, void *arg)
 				add_line_to_content_log(line, &lb, &tail);
 			}
 			replace = pxy_http_reqhdr_filter_line(line, ctx);
-			if (replace == line) {
-				evbuffer_add_printf(outbuf, "%s\r\n", line);
-			} else if (replace) {
+			if (replace != line) {
+				free(line);
+			}
+			if (replace) {
 				evbuffer_add_printf(outbuf, "%s\r\n", replace);
 				free(replace);
 			}
-			free(line);
 			if (ctx->seen_req_header) {
 				/* request header complete */
 				if (ctx->opts->deny_ocsp) {

--- a/ssl.c
+++ b/ssl.c
@@ -1679,8 +1679,10 @@ ssl_x509_names(X509 *crt)
 
 	count = (altnames ? sk_GENERAL_NAME_num(altnames) : 0) + (cn ? 2 : 1);
 	res = malloc(count * sizeof(char*));
-	if (!res)
+	if (!res) {
+		free(cn);
 		return NULL;
+	}
 	p = res;
 	if (cn)
 		*(p++) = cn;


### PR DESCRIPTION
    cachedsess.c:214:2: warning: Null pointer passed to 2nd parameter expecting 'nonnull' [core.NonNullParamChecker]
            memcpy(db->buf + tmp.sz + sizeof(port), sni, snilen);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    log.c:1716:46: warning: argument 3 of type ‘int[5]’ with mismatched bound [-Warray-parameter=]
     1716 | log_init(opts_t *opts, proxy_ctx_t *ctx, int clisock[5])
          |                                          ~~~~^~~~~~~~~~
    In file included from log.c:29:
    log.h:97:39: note: previously declared as ‘int[3]’
       97 | int log_init(opts_t *, proxy_ctx_t *, int[3]) NONNULL(1,2) WUNRES;
          |                                       ^~~~~~~

    ssl.c:1683:10: warning: Potential leak of memory pointed to by 'cn' [unix.Malloc]
                    return NULL;
                           ^~~~