### PR TITLE
Use CLOCK_REALTIME to fix pcap timestamp issue

### DIFF
--- a/logpkt.c
+++ b/logpkt.c
@@ -300,7 +300,7 @@ logpkt_pcap_write(const uint8_t *pkt, size_t pktsz, int fd)
 	pcap_rec_hdr_t rec_hdr;
 	struct timespec tv;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &tv) == -1)
+	if (clock_gettime(CLOCK_REALTIME, &tv) == -1)
 	{
 		log_err_printf("Error getting current time: %s\n",
 		               strerror(errno));

--- a/sys.c
+++ b/sys.c
@@ -1017,7 +1017,7 @@ static void
 sys_rand_seed(void) {
 	struct timespec seed;
 
-	if (clock_gettime(CLOCK_MONOTONIC, &seed) == -1) {
+	if (clock_gettime(CLOCK_REALTIME, &seed) == -1) {
 		srandom((unsigned)time(NULL));
 	} else {
 		srandom((unsigned)(seed.tv_sec ^ seed.tv_nsec));


### PR DESCRIPTION
Port over the changes outlined in https://github.com/sonertari/SSLproxy/pull/78